### PR TITLE
change format of generated hex files containing sha256tree hash of co…

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -694,7 +694,7 @@ pub fn try_from_cache(
 
         let decoded_hex = hex_to_modern_sexp(&mut allocator, &empty_symbols, cf.loc(), &hex_data)?;
         let treehash = sha256tree(decoded_hex);
-        let hash_file_name = format!("{}_hash.hex", &hex_file_name[0..hex_file_name.len() - 4]);
+        let hash_file_name = format!("{}.hex.hash", &hex_file_name[0..hex_file_name.len() - 4]);
         let treehash_hex = hex::encode(&treehash);
         opts.write_new_file(&hash_file_name, treehash_hex.as_bytes())?;
     }


### PR DESCRIPTION
Reason: it's a bit of a pain (actually, undecidable) to differentiate .hex files from _hash.hex files.

Will be happy with any discernible name.