### PR TITLE
Use an array of zero bytes instead of nil to represent "no fingerprint"

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -630,7 +630,9 @@ fn add_main_fingerprint(cf: &mut CompileForm, forms: &[Rc<SExp>]) {
         nl: cf.loc(),
         name: b"main".to_vec(),
         kind: Some(IncludeProcessType::Compiled),
-        fingerprint: sha256tree(form_list),
+        fingerprint: sha256tree(form_list)
+            .try_into()
+            .expect("sha256tree digest is 32 bytes"),
     });
 }
 

--- a/src/compiler/comptypes.rs
+++ b/src/compiler/comptypes.rs
@@ -848,8 +848,8 @@ pub struct IncludeDesc {
     /// Kind of inclusion.  Determines whether dependencies are recursed and
     /// what operation is performed on the retrieved clvm form.
     pub kind: Option<IncludeProcessType>,
-    /// Fingerprint of input
-    pub fingerprint: Vec<u8>,
+    /// Fingerprint of input (SHA-256 tree hash of file bytes when known; otherwise zero).
+    pub fingerprint: [u8; 32],
 }
 
 impl IncludeDesc {

--- a/src/compiler/diskcache.rs
+++ b/src/compiler/diskcache.rs
@@ -7,7 +7,7 @@ use crate::compiler::sexp::decode_string;
 fn cache_key(cf: &CompileForm) -> String {
     let mut include_fingerprints = Vec::new();
     for include in cf.include_forms.iter() {
-        include_fingerprints.append(&mut include.fingerprint.clone());
+        include_fingerprints.extend_from_slice(&include.fingerprint);
     }
     hex::encode(sha256tree_from_atom(&include_fingerprints))
 }

--- a/src/compiler/preprocessor/mod.rs
+++ b/src/compiler/preprocessor/mod.rs
@@ -636,7 +636,9 @@ impl Preprocessor {
             self.opts.read_new_file(self.opts.filename(), filename_clsp)
         {
             // Hash newly read input.
-            let content_hash = sha256tree_from_atom(&content);
+            let content_hash: [u8; 32] = sha256tree_from_atom(&content)
+                .try_into()
+                .expect("sha256tree_from_atom digest is 32 bytes");
             includes.push(IncludeDesc {
                 kw: kw.clone(),
                 nl: nl.clone(),
@@ -668,7 +670,9 @@ impl Preprocessor {
             nl: nl.clone(),
             name: full_name.as_bytes().to_vec(),
             kind: Some(IncludeProcessType::Module(Box::new(kind.clone()))),
-            fingerprint: sha256tree_from_atom(&content),
+            fingerprint: sha256tree_from_atom(&content)
+                .try_into()
+                .expect("sha256tree_from_atom digest is 32 bytes"),
         });
 
         Ok(res)
@@ -805,7 +809,9 @@ impl Preprocessor {
         let (full_name, content) = self.opts.read_new_file(self.opts.filename(), name_string)?;
 
         // Hash newly read input.
-        let content_hash = sha256tree_from_atom(&content);
+        let content_hash: [u8; 32] = sha256tree_from_atom(&content)
+            .try_into()
+            .expect("sha256tree_from_atom digest is 32 bytes");
         includes.push(IncludeDesc {
             name: full_name.as_bytes().to_vec(),
             fingerprint: content_hash,
@@ -1116,7 +1122,7 @@ impl Preprocessor {
                 nl: import.nl.clone(),
                 name: fname.clone(),
                 kind: Some(mod_kind.clone()),
-                fingerprint: Vec::new(),
+                fingerprint: [0u8; 32],
             }),
             mod_kind,
             fname.clone(),
@@ -1180,7 +1186,7 @@ impl Preprocessor {
                 nl: nl.clone(),
                 name: fname.clone(),
                 kind: None,
-                fingerprint: Vec::new(),
+                fingerprint: [0u8; 32],
             })));
         }
 
@@ -1217,7 +1223,7 @@ impl Preprocessor {
                         nl: nl.clone(),
                         kind: Some(IncludeProcessType::Hex),
                         name: fname.clone(),
-                        fingerprint: Vec::new(),
+                        fingerprint: [0u8; 32],
                     }),
                     IncludeProcessType::Hex,
                     name.clone(),
@@ -1229,7 +1235,7 @@ impl Preprocessor {
                         nl: nl.clone(),
                         kind: Some(IncludeProcessType::Bin),
                         name: fname.clone(),
-                        fingerprint: Vec::new(),
+                        fingerprint: [0u8; 32],
                     }),
                     IncludeProcessType::Bin,
                     name.clone(),
@@ -1241,7 +1247,7 @@ impl Preprocessor {
                         nl: nl.clone(),
                         kind: Some(IncludeProcessType::SExpression),
                         name: fname.clone(),
-                        fingerprint: Vec::new(),
+                        fingerprint: [0u8; 32],
                     }),
                     IncludeProcessType::SExpression,
                     name.clone(),
@@ -1274,7 +1280,7 @@ impl Preprocessor {
                     nl: nl.clone(),
                     kind: Some(IncludeProcessType::Compiled),
                     name: fname.clone(),
-                    fingerprint: Vec::new(),
+                    fingerprint: [0u8; 32],
                 }),
                 IncludeProcessType::Compiled,
                 name.clone(),


### PR DESCRIPTION
Doing this allows concatenation of an ordered set of signatures to uniquely represent that set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dependency fingerprinting and cache-key generation, so mistakes could cause incorrect cache hits/misses or reduced cache effectiveness despite the change being mechanically straightforward.
> 
> **Overview**
> **Standardizes include fingerprints to a fixed 32-byte SHA-256 digest.** `IncludeDesc.fingerprint` changes from `Vec<u8>` (with “no fingerprint” as empty) to `[u8; 32]` (with “no fingerprint” as all-zero bytes), and all include/namespace/embed paths now populate this field accordingly.
> 
> This updates cache key construction in `diskcache` to concatenate fixed-size fingerprints deterministically, and adds explicit `try_into()` conversions where SHA-256 results are produced (e.g., `add_main_fingerprint`, module/import hashing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c4af974ec69e5fb70244eca0a1bb2936e4e0613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->