### PR TITLE
improve hash file naming function

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -27,7 +27,7 @@ use crate::compiler::comptypes::{
     SyntheticType,
 };
 use crate::compiler::dialect::{AcceptedDialect, KNOWN_DIALECTS};
-use crate::compiler::diskcache::{set_cache_element, try_element_from_cache};
+use crate::compiler::diskcache::{hash_file_name, set_cache_element, try_element_from_cache};
 use crate::compiler::frontend::frontend;
 use crate::compiler::optimize::depgraph::{DepgraphOptions, FunctionDependencyGraph};
 use crate::compiler::optimize::get_optimizer;
@@ -740,9 +740,8 @@ pub fn try_from_cache(
 
         let decoded_hex = hex_to_modern_sexp(&mut allocator, &empty_symbols, cf.loc(), &hex_data)?;
         let treehash = sha256tree(decoded_hex);
-        let hash_file_name = format!("{}_hash.hex", &hex_file_name[0..hex_file_name.len() - 4]);
         let treehash_hex = hex::encode(&treehash);
-        opts.write_new_file(&hash_file_name, treehash_hex.as_bytes())?;
+        opts.write_new_file(&hash_file_name(&hex_file_name), treehash_hex.as_bytes())?;
     }
 
     Ok(Some(CompilerOutput::Module(CompileModuleOutput {

--- a/src/compiler/diskcache.rs
+++ b/src/compiler/diskcache.rs
@@ -4,6 +4,10 @@ use crate::compiler::clvm::sha256tree_from_atom;
 use crate::compiler::comptypes::{CompileErr, CompileForm, CompilerOpts};
 use crate::compiler::sexp::decode_string;
 
+pub fn hash_file_name(hex_file_name: &str) -> String {
+    format!("{}.hash", &hex_file_name)
+}
+
 fn cache_key(cf: &CompileForm) -> String {
     let mut include_fingerprints = Vec::new();
     for include in cf.include_forms.iter() {

--- a/src/tests/compiler/module_cache.rs
+++ b/src/tests/compiler/module_cache.rs
@@ -146,7 +146,7 @@ fn try_from_cache_hits_when_main_program_hex_present() {
     assert_eq!(mo.components[0].shortname, b"program".to_vec());
     assert_eq!(
         mo.components[0].filename,
-        TEST_CLSP_FILENAME.replace(".clsp", ".clsp.hex")
+        TEST_CLSP_FILENAME.replace(".clsp", ".hex")
     );
 
     let hex_hash_path = hex_file_name(TEST_CLSP_FILENAME.replace(".clsp", ".hex"));

--- a/src/tests/compiler/module_cache.rs
+++ b/src/tests/compiler/module_cache.rs
@@ -75,9 +75,8 @@ fn cache_dir_for(cf: &CompileForm) -> String {
 
 #[test]
 fn try_hash_clsp_and_hex_test_values_differ() {
-    let hex_bytes = sample_program_hex().as_bytes();
-    let program_bytes = TEST_CLSP_SOURCE.bytes();
-    assert!(hex_bytes != program_bytes);
+    let hex_bytes = sample_program_hex();
+    assert!(hex_bytes.as_bytes() != TEST_CLSP_SOURCE.as_bytes());
 }
 
 #[test]

--- a/src/tests/compiler/module_cache.rs
+++ b/src/tests/compiler/module_cache.rs
@@ -20,12 +20,14 @@ use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
 use crate::tests::compiler::modules::TestModuleCompilerOpts;
 
-const TEST_CLSP: &str = "module_cache_try.clsp";
+const TEST_CLSP_SOURCE: &str = "(q . 99)";
+const TEST_CLSP_FILENAME: &str = "module_cache_try.clsp";
+const TEST_HEX_FILENAME: &str = "module_cache_try.hex";
 
 fn sample_program_hex() -> String {
     let mut allocator = Allocator::new();
     let loc = Srcloc::start(&"*hex*".to_string());
-    let sexp = parse_sexp(loc.clone(), "(q . 99)".bytes()).expect("parse")[0].clone();
+    let sexp = parse_sexp(loc.clone(), TEST_CLSP_SOURCE.bytes()).expect("parse")[0].clone();
     let converted = convert_to_clvm_rs(&mut allocator, sexp).expect("convert");
     let mut stream = Stream::new(None);
     stream.write(sexp_as_bin(&mut allocator, converted));
@@ -33,7 +35,7 @@ fn sample_program_hex() -> String {
 }
 
 fn minimal_module_compileform() -> CompileForm {
-    let loc = Srcloc::start(&TEST_CLSP.to_string());
+    let loc = Srcloc::start(&TEST_CLSP_FILENAME.to_string());
     CompileForm {
         loc: loc.clone(),
         include_forms: Vec::new(),
@@ -44,7 +46,7 @@ fn minimal_module_compileform() -> CompileForm {
 }
 
 fn main_export() -> Export {
-    let loc = Srcloc::start(&TEST_CLSP.to_string());
+    let loc = Srcloc::start(&TEST_CLSP_FILENAME.to_string());
     Export::MainProgram(ExportProgramDesc {
         loc: loc.clone(),
         kw_loc: None,
@@ -54,7 +56,7 @@ fn main_export() -> Export {
 }
 
 fn function_export(name: &[u8], as_name: Option<Vec<u8>>) -> Export {
-    let loc = Srcloc::start(&TEST_CLSP.to_string());
+    let loc = Srcloc::start(&TEST_CLSP_FILENAME.to_string());
     Export::Function(Box::new(ExportFunctionDesc {
         loc: loc.clone(),
         kw_loc: None,
@@ -72,9 +74,21 @@ fn cache_dir_for(cf: &CompileForm) -> String {
 }
 
 #[test]
+fn try_hash_clsp_and_hex_test_values_differ() {
+    let hex_bytes = sample_program_hex().as_bytes();
+    let program_bytes = TEST_CLSP_SOURCE.bytes();
+    assert!(hex_bytes != program_bytes);
+}
+
+#[test]
+fn try_clsp_hash_and_hex_hash_filenames_differ() {
+    assert(hash_filename(TEST_CLSP_FILENAME) != hash_filename(TEST_HEX_FILENAME))
+}
+
+#[test]
 fn try_from_cache_returns_none_when_cache_missing() {
     let cf = minimal_module_compileform();
-    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP));
+    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP_FILENAME));
     let wrapped = TestModuleCompilerOpts::new(orig_opts);
     let opts: Rc<dyn CompilerOpts> = Rc::new(wrapped);
     let out = try_from_cache(opts, &cf, &[main_export()]).expect("try_from_cache");
@@ -85,11 +99,11 @@ fn try_from_cache_returns_none_when_cache_missing() {
 fn try_from_cache_returns_none_when_second_export_missing() {
     let cf = minimal_module_compileform();
     let hex = sample_program_hex();
-    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP));
+    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP_FILENAME));
     let wrapped = TestModuleCompilerOpts::new(orig_opts);
     let prefix = cache_dir_for(&cf);
     wrapped.set_file_content(
-        format!("{}{}", prefix, TEST_CLSP.replace(".clsp", ".hex")),
+        format!("{}{}", prefix, TEST_HEX_FILENAME),
         hex.as_bytes().to_vec(),
     );
     let opts: Rc<dyn CompilerOpts> = Rc::new(wrapped);
@@ -101,11 +115,11 @@ fn try_from_cache_returns_none_when_second_export_missing() {
 #[test]
 fn try_from_cache_returns_none_on_invalid_cached_hex() {
     let cf = minimal_module_compileform();
-    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP));
+    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP_FILENAME));
     let wrapped = TestModuleCompilerOpts::new(orig_opts);
     let prefix = cache_dir_for(&cf);
     wrapped.set_file_content(
-        format!("{}{}", prefix, TEST_CLSP.replace(".clsp", ".hex")),
+        format!("{}{}", prefix, TEST_HEX_FILENAME),
         b"not_valid_hex_clvm_zzzz".to_vec(),
     );
     let opts: Rc<dyn CompilerOpts> = Rc::new(wrapped);
@@ -117,10 +131,10 @@ fn try_from_cache_returns_none_on_invalid_cached_hex() {
 fn try_from_cache_hits_when_main_program_hex_present() {
     let cf = minimal_module_compileform();
     let hex = sample_program_hex();
-    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP));
+    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP_FILENAME));
     let wrapped = TestModuleCompilerOpts::new(orig_opts);
     let prefix = cache_dir_for(&cf);
-    let main_hex_path = format!("{}{}", prefix, TEST_CLSP.replace(".clsp", ".hex"));
+    let main_hex_path = format!("{}{}", prefix, TEST_HEX_FILENAME);
     wrapped.set_file_content(main_hex_path.clone(), hex.as_bytes().to_vec());
     let opts: Rc<dyn CompilerOpts> = Rc::new(wrapped.clone());
 
@@ -132,12 +146,12 @@ fn try_from_cache_hits_when_main_program_hex_present() {
     assert_eq!(mo.components[0].shortname, b"program".to_vec());
     assert_eq!(
         mo.components[0].filename,
-        TEST_CLSP.replace(".clsp", ".hex")
+        TEST_CLSP_FILENAME.replace(".clsp", ".clsp.hex")
     );
 
-    let hash_path = hex_file_name(TEST_CLSP);
+    let hex_hash_path = hex_file_name(TEST_CLSP_FILENAME.replace(".clsp", ".hex"));
     assert!(
-        wrapped.get_written_file(&hash_path).is_some(),
+        wrapped.get_written_file(&hex_hash_path).is_some(),
         "expected treehash sidecar {hash_path}, got {:?}",
         wrapped.list_written_files()
     );
@@ -147,12 +161,16 @@ fn try_from_cache_hits_when_main_program_hex_present() {
 fn try_from_cache_uses_as_name_for_hex_path() {
     let cf = minimal_module_compileform();
     let hex = sample_program_hex();
-    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP));
+    let orig_opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP_FILENAME));
     let wrapped = TestModuleCompilerOpts::new(orig_opts);
     let prefix = cache_dir_for(&cf);
     let export = function_export(b"F", Some(b"RenamedF".to_vec()));
     // Matches `create_hex_output_path`: `<stem>_<func>.hex` with func dotted with `hex`.
-    let rel_hex = format!("{}_{}.hex", TEST_CLSP.trim_end_matches(".clsp"), "RenamedF");
+    let rel_hex = format!(
+        "{}_{}.hex",
+        TEST_CLSP_FILENAME.trim_end_matches(".clsp"),
+        "RenamedF"
+    );
     let cache_path = format!("{prefix}{rel_hex}");
     wrapped.set_file_content(cache_path, hex.as_bytes().to_vec());
     let opts: Rc<dyn CompilerOpts> = Rc::new(wrapped);

--- a/src/tests/compiler/module_cache.rs
+++ b/src/tests/compiler/module_cache.rs
@@ -82,7 +82,7 @@ fn try_hash_clsp_and_hex_test_values_differ() {
 
 #[test]
 fn try_clsp_hash_and_hex_hash_filenames_differ() {
-    assert(hash_filename(TEST_CLSP_FILENAME) != hash_filename(TEST_HEX_FILENAME))
+    assert!(hash_file_name(TEST_CLSP_FILENAME) != hash_file_name(TEST_HEX_FILENAME))
 }
 
 #[test]
@@ -149,10 +149,10 @@ fn try_from_cache_hits_when_main_program_hex_present() {
         TEST_CLSP_FILENAME.replace(".clsp", ".hex")
     );
 
-    let hex_hash_path = hex_file_name(TEST_CLSP_FILENAME.replace(".clsp", ".hex"));
+    let hex_hash_path = hash_file_name(TEST_HEX_FILENAME);
     assert!(
         wrapped.get_written_file(&hex_hash_path).is_some(),
-        "expected treehash sidecar {hash_path}, got {:?}",
+        "expected treehash sidecar {hex_hash_path}, got {:?}",
         wrapped.list_written_files()
     );
 }

--- a/src/tests/compiler/module_cache.rs
+++ b/src/tests/compiler/module_cache.rs
@@ -14,6 +14,7 @@ use crate::compiler::comptypes::{
     BodyForm, CompileForm, CompilerOpts, CompilerOutput, Export, ExportFunctionDesc,
     ExportProgramDesc, NameAndLoc,
 };
+use crate::compiler::diskcache::hash_file_name;
 use crate::compiler::diskcache::module_cache_key_hex;
 use crate::compiler::sexp::{parse_sexp, SExp};
 use crate::compiler::srcloc::Srcloc;
@@ -134,7 +135,7 @@ fn try_from_cache_hits_when_main_program_hex_present() {
         TEST_CLSP.replace(".clsp", ".hex")
     );
 
-    let hash_path = format!("{}_hash.hex", TEST_CLSP.trim_end_matches(".clsp"));
+    let hash_path = hex_file_name(TEST_CLSP);
     assert!(
         wrapped.get_written_file(&hash_path).is_some(),
         "expected treehash sidecar {hash_path}, got {:?}",


### PR DESCRIPTION
A "hash" file in this context is a file containing the sha256 of the input file. This patch changes the code that generates the name for that file:

- move to a function to reduce chance of errors in the future, and encapsulate details
- change transform so that input filename cannot overlap with output filename (eg. `ls *hex big.hex, big_hash.hex`; hash_file_name(big.hex) -> big_hash.hex)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk name of the treehash sidecar written alongside cached `.hex` outputs, which may break tooling that expects the previous `*_hash.hex` naming. Logic is small and covered by updated tests, but it affects build artifacts and cache behavior.
> 
> **Overview**
> Refactors module cache rebuild output to use a shared `hash_file_name()` helper when writing the sha256tree sidecar for cached `.hex` artifacts.
> 
> Updates the sidecar naming scheme from the previous `*_hash.hex` pattern to a non-overlapping `"<hex_filename>.hash"` form, and adjusts/extends `module_cache` tests to validate the new naming and paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 579174350bf8a19d720a0084e762c1565f20885f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->