### PR TITLE
Propagate module dialect before compilation

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -31,6 +31,7 @@ use crate::compiler::diskcache::{set_cache_element, try_element_from_cache};
 use crate::compiler::frontend::frontend;
 use crate::compiler::optimize::depgraph::{DepgraphOptions, FunctionDependencyGraph};
 use crate::compiler::optimize::get_optimizer;
+use crate::compiler::preprocessor::detect_chialisp_module;
 use crate::compiler::prims;
 use crate::compiler::resolve::{find_helper_target, resolve_namespaces};
 use crate::compiler::sexp::{decode_string, enlist, parse_sexp_flags, SExp};
@@ -398,11 +399,11 @@ pub fn compile_module(
     // Module style is new, so there will never be a time when we don't want every
     // bug fix that existed before it was released.
     dialect.int_fix = true;
+    dialect.cse_dominance = true;
     if let Some(stepping) = dialect.stepping {
         if stepping < 26 {
             dialect.stepping = Some(26);
         }
-        dialect.cse_dominance = true;
     }
     opts = opts.set_optimize(true).set_dialect(dialect);
 
@@ -827,9 +828,13 @@ fn add_inline_hash_for_constant(program: &mut CompileForm, loc: &Srcloc, fun_nam
 /// Given a set of untreated input forms, compile it as a clvm program.
 pub fn compile_pre_forms(
     context: &mut BasicCompileContext,
-    opts: Rc<dyn CompilerOpts>,
+    mut opts: Rc<dyn CompilerOpts>,
     pre_forms: &[Rc<SExp>],
 ) -> Result<CompilerOutput, CompileErr> {
+    if let Some(dialect) = detect_chialisp_module(Srcloc::start(&opts.filename()), pre_forms)? {
+        opts = opts.set_stdenv(dialect.strict).set_dialect(dialect);
+    }
+
     let p0 = frontend(opts.clone(), pre_forms)?;
 
     match p0 {


### PR DESCRIPTION
## Summary
- Apply the detected module dialect before frontend, cache lookup, and module compilation.
- Enable module-only CSE dominance semantics even when callers enter module compilation with default options.

## Test plan
- cargo test test_unlabeled_module_file
- cargo test test_cse_tricky_2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compile entry and optimizer dialect flags; wrong detection or dialect propagation could change codegen or cache behavior for module inputs.
> 
> **Overview**
> **`compile_pre_forms`** now runs **`detect_chialisp_module`** on raw pre-forms and updates **`opts`** with the module **`dialect`** and **`stdenv`** (from **`dialect.strict`**) **before** **`frontend`**, so module files get the right language settings even when compilation starts with default options (affects parsing, disk cache keys, and the module path).
> 
> In **`compile_module`**, **`cse_dominance`** is always turned on for modules instead of only when **`stepping < 26`**, so module CSE dominance semantics apply consistently regardless of stepping on the incoming dialect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25beafc6a2622d499cac0ba890c645a8e32b9607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->