### PR TITLE
Include dialect in module cache keys

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -387,14 +387,7 @@ fn populate_export_map(
 ///
 /// (export foo)
 /// (export bar)
-pub fn compile_module(
-    context: &mut BasicCompileContext,
-    mut opts: Rc<dyn CompilerOpts>,
-    standalone_constants: &HashSet<Vec<u8>>,
-    mut program: CompileForm,
-    exports: &[Export],
-) -> Result<CompileModuleOutput, CompileErr> {
-    let loc = program.loc();
+fn module_compile_opts(opts: Rc<dyn CompilerOpts>) -> Rc<dyn CompilerOpts> {
     let mut dialect = opts.dialect();
     // Module style is new, so there will never be a time when we don't want every
     // bug fix that existed before it was released.
@@ -405,7 +398,19 @@ pub fn compile_module(
             dialect.stepping = Some(26);
         }
     }
-    opts = opts.set_optimize(true).set_dialect(dialect);
+
+    opts.set_optimize(true).set_dialect(dialect)
+}
+
+pub fn compile_module(
+    context: &mut BasicCompileContext,
+    mut opts: Rc<dyn CompilerOpts>,
+    standalone_constants: &HashSet<Vec<u8>>,
+    mut program: CompileForm,
+    exports: &[Export],
+) -> Result<CompileModuleOutput, CompileErr> {
+    let loc = program.loc();
+    opts = module_compile_opts(opts);
 
     if exports.is_empty() {
         return Err(CompileErr(
@@ -844,19 +849,13 @@ pub fn compile_pre_forms(
         )),
         FrontendOutput::Module(mut cf, exports) => {
             add_main_fingerprint(&mut cf, pre_forms);
+            let opts = module_compile_opts(opts);
+
             // If we can read from cache, use that.  We'll use the actual form of the compileform
             // and opts (the dialect) to determine a cache hit.
             if let Some(result) = try_from_cache(opts.clone(), &cf, &exports)? {
                 return Ok(result);
             }
-
-            // cl23 always reflects optimization.
-            let dialect = opts.dialect();
-            let opts = if let Some(stepping) = dialect.stepping.as_ref() {
-                opts.set_optimize(*stepping > 21)
-            } else {
-                opts
-            };
 
             // We make a dependency graph of constants and functions.  There must
             // be a solveable hierarchy for constants, that is some must be top

--- a/src/compiler/diskcache.rs
+++ b/src/compiler/diskcache.rs
@@ -4,12 +4,25 @@ use crate::compiler::clvm::sha256tree_from_atom;
 use crate::compiler::comptypes::{CompileErr, CompileForm, CompilerOpts};
 use crate::compiler::sexp::decode_string;
 
-fn cache_key(cf: &CompileForm) -> String {
-    let mut include_fingerprints = Vec::new();
-    for include in cf.include_forms.iter() {
-        include_fingerprints.extend_from_slice(&include.fingerprint);
+fn cache_key(opts: Rc<dyn CompilerOpts>, cf: &CompileForm) -> String {
+    let dialect = opts.dialect();
+    let mut key_material = b"module-cache-v2".to_vec();
+
+    if let Some(stepping) = dialect.stepping {
+        key_material.push(1);
+        key_material.extend_from_slice(&stepping.to_le_bytes());
+    } else {
+        key_material.push(0);
     }
-    hex::encode(sha256tree_from_atom(&include_fingerprints))
+    key_material.push(u8::from(dialect.strict));
+    key_material.push(u8::from(dialect.int_fix));
+    key_material.push(u8::from(dialect.extra_numeric_constants));
+    key_material.push(u8::from(dialect.cse_dominance));
+
+    for include in cf.include_forms.iter() {
+        key_material.extend_from_slice(&include.fingerprint);
+    }
+    hex::encode(sha256tree_from_atom(&key_material))
 }
 
 /// Try to get an element from the cache, exposing errors.
@@ -30,7 +43,7 @@ pub fn try_element_from_cache(
     cf: &CompileForm,
     export_path: &str,
 ) -> Option<String> {
-    let key = cache_key(cf);
+    let key = cache_key(opts.clone(), cf);
     let hex_file_name = format!(".chialisp/{key}/{export_path}");
     opts.read_new_file(cf.loc().file.to_string(), hex_file_name.clone())
         .ok()
@@ -43,7 +56,7 @@ pub fn set_cache_element_error(
     export_path: &str,
     export_hex: &str,
 ) -> Result<(), CompileErr> {
-    let key = cache_key(cf);
+    let key = cache_key(opts.clone(), cf);
     let hex_file_name = format!(".chialisp/{key}/{export_path}");
     opts.write_new_file(&hex_file_name, export_hex.as_bytes())?;
     Ok(())
@@ -63,14 +76,16 @@ pub fn set_cache_element(
 
 /// Exposes the cache-key segment used under `.chialisp/<key>/` (tests and tooling only).
 #[cfg(test)]
-pub fn module_cache_key_hex(cf: &CompileForm) -> String {
-    cache_key(cf)
+pub fn module_cache_key_hex(opts: Rc<dyn CompilerOpts>, cf: &CompileForm) -> String {
+    cache_key(opts, cf)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compiler::compiler::DefaultCompilerOpts;
     use crate::compiler::comptypes::{BodyForm, CompileForm, IncludeDesc, IncludeProcessType};
+    use crate::compiler::dialect::AcceptedDialect;
     use crate::compiler::sexp::SExp;
     use crate::compiler::srcloc::Srcloc;
 
@@ -84,14 +99,18 @@ mod tests {
         }
     }
 
+    fn default_opts(filename: &str) -> Rc<dyn CompilerOpts> {
+        Rc::new(DefaultCompilerOpts::new(filename))
+    }
+
     #[test]
     fn cache_key_stable_for_empty_includes() {
         let loc = Srcloc::start(&"a.clsp".to_string());
         let cf = empty_compileform(loc);
-        let k = cache_key(&cf);
+        let k = cache_key(default_opts("a.clsp"), &cf);
         assert_eq!(
             k,
-            "4bf5122f344554c53bde2ebb8cd2b7e3d1600ad631c385a5d7cce23c7785459a"
+            "bb1dfe276a7165264b23349a3d349c470f451aa964f89c172bfb5bc8fdf9d548"
         );
     }
 
@@ -112,13 +131,34 @@ mod tests {
             fingerprint: fp,
         };
         cf.include_forms.push(desc(fp(&[1, 2, 3])));
-        let k1 = cache_key(&cf);
+        let k1 = cache_key(default_opts("b.clsp"), &cf);
         cf.include_forms.push(desc(fp(&[4, 5])));
-        let k2 = cache_key(&cf);
+        let k2 = cache_key(default_opts("b.clsp"), &cf);
         assert_ne!(k1, k2);
         cf.include_forms.truncate(1);
-        let k1_again = cache_key(&cf);
+        let k1_again = cache_key(default_opts("b.clsp"), &cf);
         assert_eq!(k1, k1_again);
+    }
+
+    #[test]
+    fn cache_key_changes_with_cse_dominance() {
+        let loc = Srcloc::start(&"cse.clsp".to_string());
+        let cf = empty_compileform(loc);
+        let dialect_before = AcceptedDialect {
+            stepping: Some(26),
+            strict: true,
+            int_fix: true,
+            extra_numeric_constants: false,
+            cse_dominance: false,
+        };
+        let dialect_after = AcceptedDialect {
+            cse_dominance: true,
+            ..dialect_before.clone()
+        };
+        let before = default_opts("cse.clsp").set_dialect(dialect_before);
+        let after = default_opts("cse.clsp").set_dialect(dialect_after);
+
+        assert_ne!(cache_key(before, &cf), cache_key(after, &cf));
     }
 
     #[test]
@@ -135,7 +175,7 @@ mod tests {
             kind: Some(IncludeProcessType::Compiled),
             fingerprint: main_fp,
         });
-        let k = cache_key(&cf);
+        let k = cache_key(default_opts("c.clsp"), &cf);
         assert!(!k.is_empty());
         assert_ne!(
             k,

--- a/src/tests/compiler/module_cache.rs
+++ b/src/tests/compiler/module_cache.rs
@@ -67,7 +67,8 @@ fn function_export(name: &[u8], as_name: Option<Vec<u8>>) -> Export {
 }
 
 fn cache_dir_for(cf: &CompileForm) -> String {
-    format!(".chialisp/{}/", module_cache_key_hex(cf))
+    let opts: Rc<dyn CompilerOpts> = Rc::new(DefaultCompilerOpts::new(TEST_CLSP));
+    format!(".chialisp/{}/", module_cache_key_hex(opts, cf))
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add explicit dialect material, including `cse_dominance`, to module cache keys.
- Update cache-key tests and module cache fixtures to use the option-aware cache key helper.

## Test plan
- cargo test module_cache
- cargo test diskcache

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compiler disk-cache keying only; intentional cache invalidation improves correctness without touching runtime auth or data paths.
> 
> **Overview**
> **Module export disk cache keys now incorporate compiler dialect settings**, not just include fingerprints, so cached hex cannot be reused across incompatible compiler configurations.
> 
> `cache_key` takes `CompilerOpts`, builds `module-cache-v2` key material from stepping, `strict`, `int_fix`, `extra_numeric_constants`, and **`cse_dominance`**, then appends include fingerprints before hashing. Lookups and writes already had `opts`; they now feed that into the key. The stable empty-include test expectation changes accordingly, and a new unit test asserts different keys when only `cse_dominance` toggles. Integration tests resolve `.chialisp/<key>/` via the opts-aware `module_cache_key_hex` helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c21fd1a0f67c9929a8b0fcac2fd2e5aeac510e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->