### PR TITLE
CHIA-4241: Remove _write, since it isn't used anymore

### DIFF
--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -12,15 +12,13 @@ use clvm_rs::error::EvalErr;
 use clvm_rs::reduction::{Reduction, Response};
 use clvm_rs::run_program::run_program_with_pre_eval;
 
-use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType, Stream};
+use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
 use crate::classic::clvm::OPERATORS_LATEST_VERSION;
 
-use crate::classic::clvm::keyword_from_atom;
 use crate::classic::clvm::sexp::proper_list;
 
-use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble_to_ir_with_kw};
+use crate::classic::clvm_tools::binutils::assemble_from_ir;
 use crate::classic::clvm_tools::ir::reader::read_ir;
-use crate::classic::clvm_tools::ir::writer::write_ir_to_stream;
 use crate::classic::clvm_tools::sha256tree::TreeHash;
 use crate::classic::clvm_tools::stages::stage_0::{
     choose_run_flags, DefaultProgramRunner, OriginalDialect, RunProgramOption, TRunProgram,
@@ -264,39 +262,6 @@ impl CompilerOperatorsInternal {
         }
     }
 
-    fn write(&self, allocator: &Allocator, sexp: NodePtr) -> Response {
-        if let SExp::Pair(filename_sexp, r) = allocator.sexp(sexp) {
-            if let SExp::Pair(data, _) = allocator.sexp(r) {
-                if let SExp::Atom = allocator.sexp(filename_sexp) {
-                    let filename_atom = allocator.atom(filename_sexp);
-                    let filename_bytes =
-                        Bytes::new(Some(BytesFromType::Raw(filename_atom.as_ref().to_vec())));
-                    let ir = disassemble_to_ir_with_kw(
-                        allocator,
-                        data,
-                        keyword_from_atom(self.get_disassembly_ver()),
-                        true,
-                    );
-                    let mut stream = Stream::new(None);
-                    write_ir_to_stream(Rc::new(ir), &mut stream, self.language_flags);
-                    return fs::write(filename_bytes.decode(), stream.get_value().decode())
-                        .map_err(|_| {
-                            EvalErr::InternalError(
-                                sexp,
-                                format!("failed to write {}", filename_bytes.decode()),
-                            )
-                        })
-                        .map(|_| Reduction(1, NodePtr::NIL));
-                }
-            }
-        }
-
-        Err(EvalErr::InternalError(
-            sexp,
-            "failed to write data".to_string(),
-        ))
-    }
-
     fn get_compile_filename(&self, allocator: &mut Allocator) -> Response {
         let converted_filename = allocator.new_atom(self.source_file.as_bytes())?;
         Ok(Reduction(1, converted_filename))
@@ -378,12 +343,6 @@ impl CompilerOperatorsInternal {
 
         Ok(Reduction(1, NodePtr::NIL))
     }
-
-    fn get_disassembly_ver(&self) -> usize {
-        self.get_compiler_opts()
-            .and_then(|o| o.disassembly_ver())
-            .unwrap_or(OPERATORS_LATEST_VERSION)
-    }
 }
 
 impl Dialect for CompilerOperatorsInternal {
@@ -449,8 +408,6 @@ impl Dialect for CompilerOperatorsInternal {
                 let opbuf = op_atom.as_ref();
                 if opbuf == b"_read" {
                     self.read(allocator, sexp)
-                } else if opbuf == b"_write" {
-                    self.write(allocator, sexp)
                 } else if opbuf == b"com" {
                     do_com_prog_for_dialect(self.get_runner(), allocator, sexp)
                 } else if opbuf == b"opt" {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dead-code removal with no remaining `_write` references; compile-time `_read` and other operators are unchanged.
> 
> **Overview**
> Removes the compiler dialect’s **`_write`** operator and all code that only supported it.
> 
> The deleted **`write`** path disassembled CLVM to IR and wrote source to disk via **`fs::write`**. The **`Dialect::op`** dispatch no longer handles **`_write`**, and **`get_disassembly_ver`** (used only for that path) is removed. Unused imports (**`Stream`**, **`keyword_from_atom`**, **`disassemble_to_ir_with_kw`**, **`write_ir_to_stream`**) are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62c09a99dd47fdacf0329ff24b2722b13232dfc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->