### PR TITLE
Expand modern com forms before classic codegen

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -35,7 +35,7 @@ use crate::compiler::comptypes::{
 use crate::compiler::dialect::{AcceptedDialect, KNOWN_DIALECTS};
 use crate::compiler::frontend::frontend;
 use crate::compiler::optimize::depgraph::{DepgraphOptions, FunctionDependencyGraph};
-use crate::compiler::optimize::get_optimizer;
+use crate::compiler::optimize::{expand_com_forms, get_optimizer};
 use crate::compiler::preprocessor::detect_chialisp_module;
 use crate::compiler::prims;
 use crate::compiler::resolve::{find_helper_target, resolve_namespaces};
@@ -166,7 +166,12 @@ pub fn finish_compilation(
     p2: CompileForm,
 ) -> Result<SExp, CompileErr> {
     if opts.dialect().classic_codegen {
-        return classic_codegen(opts, p2);
+        let mut modern_dialect = opts.dialect();
+        modern_dialect.classic_codegen = false;
+        let modern_opts = opts.set_dialect(modern_dialect);
+        let optimized = context.post_desugar_optimization(modern_opts.clone(), p2)?;
+        let expanded = expand_com_forms(context, modern_opts, optimized)?;
+        return classic_codegen(opts, expanded);
     }
 
     let p3 = context.post_desugar_optimization(opts.clone(), p2)?;
@@ -238,11 +243,7 @@ pub fn compile_from_compileform(
     opts: Rc<dyn CompilerOpts>,
     p0: CompileForm,
 ) -> Result<SExp, CompileErr> {
-    let p1 = if opts.dialect().classic_codegen {
-        p0
-    } else {
-        context.frontend_optimization(opts.clone(), p0)?
-    };
+    let p1 = context.frontend_optimization(opts.clone(), p0)?;
 
     // Resolve includes, convert program source to lexemes
     let p2 = do_desugar(opts.clone(), &p1)?;
@@ -816,7 +817,14 @@ pub fn compile_pre_forms(
         opts = opts.set_stdenv(dialect.strict).set_dialect(dialect);
     }
 
-    let p0 = frontend(opts.clone(), pre_forms)?;
+    let frontend_opts = if opts.dialect().classic_codegen {
+        let mut modern_dialect = opts.dialect();
+        modern_dialect.classic_codegen = false;
+        opts.set_dialect(modern_dialect)
+    } else {
+        opts.clone()
+    };
+    let p0 = frontend(frontend_opts, pre_forms)?;
 
     match p0 {
         FrontendOutput::CompileForm(p0) => Ok(CompilerOutput::Program(

--- a/src/compiler/optimize/mod.rs
+++ b/src/compiler/optimize/mod.rs
@@ -639,6 +639,8 @@ fn fe_opt(
     context: &mut BasicCompileContext,
     opts: Rc<dyn CompilerOpts>,
     compileform: CompileForm,
+    only_inline: bool,
+    use_main_env: bool,
 ) -> Result<CompileForm, CompileErr> {
     let runner = context.runner();
     let evaluator = Evaluator::new(opts.clone(), runner.clone(), compileform.helpers.clone());
@@ -671,13 +673,20 @@ fn fe_opt(
         }
     }
     let new_evaluator = Evaluator::new(opts.clone(), runner.clone(), optimized_helpers.clone());
+    let mut main_env = HashMap::new();
+    let main_args = if use_main_env {
+        build_reflex_captures(&mut main_env, compileform.args.clone());
+        compileform.args.clone()
+    } else {
+        Rc::new(SExp::Nil(compileform.args.loc()))
+    };
 
     let shrunk = new_evaluator.shrink_bodyform(
         context,
-        Rc::new(SExp::Nil(compileform.args.loc())),
-        &HashMap::new(),
+        main_args,
+        &main_env,
         compileform.exp.clone(),
-        true,
+        only_inline,
         Some(EVAL_STACK_LIMIT),
     )?;
 
@@ -686,6 +695,16 @@ fn fe_opt(
         exp: shrunk,
         ..compileform
     })
+}
+
+/// Expand compiler forms using the modern evaluator before handing a program to
+/// a backend that does not implement modern compiler-form semantics.
+pub fn expand_com_forms(
+    context: &mut BasicCompileContext,
+    opts: Rc<dyn CompilerOpts>,
+    compileform: CompileForm,
+) -> Result<CompileForm, CompileErr> {
+    fe_opt(context, opts, compileform, true, true)
 }
 
 pub fn run_optimizer(

--- a/src/compiler/optimize/strategy.rs
+++ b/src/compiler/optimize/strategy.rs
@@ -43,7 +43,7 @@ impl Optimization for ExistingStrategy {
                 Box::new(self.clone()),
             );
             // Front end optimization
-            fe_opt(wrapper.context(), opts.clone(), p0)
+            fe_opt(wrapper.context(), opts.clone(), p0, true, false)
         } else {
             Ok(p0)
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- run neoclassic frontend macro processing with modern compiler-form semantics
- apply modern post-desugar and `com` expansion before invoking classic stage 2
- preserve bound module arguments while expanding compiler forms

## Test plan
- `cargo test test_equivalence_smoke_if_macro_modern_neoclassic -- --nocapture`
- `cargo test test_equivalence_smoke_modern_neoclassic -- --nocapture`
- `cargo test --lib`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c716f7c-d8db-48cb-a4d6-013783c95ead?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c716f7c-d8db-48cb-a4d6-013783c95ead&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

