### PR TITLE
Fix classic codegen let environments in cldb

### DIFF
--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -1720,7 +1720,11 @@ pub fn process_helper_let_bindings(
     while i < result.len() {
         match result[i].clone() {
             HelperForm::Defun(inline, defun) => {
-                let context = if inline {
+                // Let helpers take the enclosing function's argument tree as
+                // their first argument. Classic codegen exposes function
+                // arguments directly via @*env*, so reconstruct that tree at
+                // the call site even for non-inline functions.
+                let context = if inline || opts.dialect().classic_codegen {
                     Some(defun.args.clone())
                 } else {
                     None

--- a/src/tests/classic/run.rs
+++ b/src/tests/classic/run.rs
@@ -2840,3 +2840,12 @@ fn test_equivalence_smoke_if_macro_modern_neoclassic() {
         assert_eq!(output_neo.trim(), output_modern.trim());
     }
 }
+
+#[test]
+fn test_equivalence_mandelbrot_classic() {
+    let program = fs::read_to_string("resources/tests/mandelbrot/mandelbrot.clsp").unwrap();
+    let classic = program.replace("cl-21", "cl-26-classic").to_string();
+    let mandelbrot_clvm = do_basic_run(&vec!["run".to_string(), classic.to_string()]);
+    let mandelbrot_smoke_run = do_basic_brun(&vec!["brun".to_string(), mandelbrot_clvm, "(16 16 32 32 16)".to_string()]);
+    assert_eq!(mandelbrot_smoke_run.trim(), "||E");
+}

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -358,19 +358,28 @@ fn test_classic_codegen_mandelbrot() {
     let input_program = fs::read_to_string(input_file)
         .expect("test resource should exist")
         .replace("*standard-cl-21*", "*standard-cl-26-classic*");
-    let result = compile_and_run_program_with_tree(
-        input_file,
-        &input_program,
-        "(-192 -128 -144 -96 8)",
-        &vec![],
-        0,
-    );
+    let mut allocator = Allocator::new();
+    let runner = Rc::new(DefaultProgramRunner::new());
+    let opts = Rc::new(DefaultCompilerOpts::new(input_file)).set_optimize(false);
+    let mut symbols = HashMap::new();
+    let program = compile_file(&mut allocator, runner, opts, &input_program, &mut symbols)
+        .expect("should compile");
+    let args = parse_sexp(Srcloc::start("*args*"), "(-192 -128 -144 -96 8)".bytes())
+        .expect("should parse args")[0]
+        .clone();
+    let program_lines = Rc::new(input_program.lines().map(str::to_string).collect());
 
     assert_eq!(
-        result.last().and_then(|entry| entry.get("Final")),
-        Some(&YamlElement::String(
-            "3356114000950459963475899699747220812557867594760040767593731831711045".to_string()
-        ))
+        run_clvm_in_cldb(
+            input_file,
+            program_lines,
+            Rc::new(program.to_sexp()),
+            symbols,
+            args,
+            &mut DoesntWatchCldb {},
+            0,
+        ),
+        Some("3356114000950459963475899699747220812557867594760040767593731831711045".to_string())
     );
 }
 

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -360,7 +360,9 @@ fn test_classic_codegen_mandelbrot() {
         .replace("*standard-cl-21*", "*standard-cl-26-classic*");
     let mut allocator = Allocator::new();
     let runner = Rc::new(DefaultProgramRunner::new());
-    let cldb_opts = Rc::new(DefaultCompilerOpts::new(input_file)).set_optimize(false);
+    // The run and cldb commands both enable frontend optimization for
+    // stepping dialects newer than 22.
+    let cldb_opts = Rc::new(DefaultCompilerOpts::new(input_file)).set_optimize(true);
     let mut symbols = HashMap::new();
     let cldb_program = compile_file(
         &mut allocator,

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -353,6 +353,28 @@ fn test_cldb_hierarchy_mode() {
 }
 
 #[test]
+fn test_classic_codegen_mandelbrot() {
+    let input_file = "resources/tests/mandelbrot/mandelbrot.clsp";
+    let input_program = fs::read_to_string(input_file)
+        .expect("test resource should exist")
+        .replace("*standard-cl-21*", "*standard-cl-26-classic*");
+    let result = compile_and_run_program_with_tree(
+        input_file,
+        &input_program,
+        "(-192 -128 -144 -96 8)",
+        &vec![],
+        0,
+    );
+
+    assert_eq!(
+        result.last().and_then(|entry| entry.get("Final")),
+        Some(&YamlElement::String(
+            "3356114000950459963475899699747220812557867594760040767593731831711045".to_string()
+        ))
+    );
+}
+
+#[test]
 fn test_execute_program_and_capture_arguments() {
     let compiled_symbols_text =
         fs::read_to_string("resources/tests/cldb_tree/pool_member_innerpuz_extra.sym")

--- a/src/tests/compiler/cldb.rs
+++ b/src/tests/compiler/cldb.rs
@@ -360,10 +360,26 @@ fn test_classic_codegen_mandelbrot() {
         .replace("*standard-cl-21*", "*standard-cl-26-classic*");
     let mut allocator = Allocator::new();
     let runner = Rc::new(DefaultProgramRunner::new());
-    let opts = Rc::new(DefaultCompilerOpts::new(input_file)).set_optimize(false);
+    let cldb_opts = Rc::new(DefaultCompilerOpts::new(input_file)).set_optimize(false);
     let mut symbols = HashMap::new();
-    let program = compile_file(&mut allocator, runner, opts, &input_program, &mut symbols)
-        .expect("should compile");
+    let cldb_program = compile_file(
+        &mut allocator,
+        runner.clone(),
+        cldb_opts,
+        &input_program,
+        &mut symbols,
+    )
+    .expect("cldb should compile");
+    let run_opts = Rc::new(DefaultCompilerOpts::new(input_file)).set_optimize(true);
+    let run_program = compile_file(
+        &mut allocator,
+        runner,
+        run_opts,
+        &input_program,
+        &mut HashMap::new(),
+    )
+    .expect("run should compile");
+    assert_eq!(cldb_program.to_sexp(), run_program.to_sexp());
     let args = parse_sexp(Srcloc::start("*args*"), "(-192 -128 -144 -96 8)".bytes())
         .expect("should parse args")[0]
         .clone();
@@ -373,7 +389,7 @@ fn test_classic_codegen_mandelbrot() {
         run_clvm_in_cldb(
             input_file,
             program_lines,
-            Rc::new(program.to_sexp()),
+            Rc::new(cldb_program.to_sexp()),
             symbols,
             args,
             &mut DoesntWatchCldb {},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- reconstruct enclosing function argument trees when hoisting lets for classic code generation
- add a cldb-runner regression test using the Mandelbrot program with `*standard-cl-26-classic*`
- compile through both cldb and `run`-equivalent paths and assert that their CLVM is identical

## Root cause
The modern frontend hoists `let` forms into helper functions whose first argument is the enclosing function's argument tree. Classic codegen exposes non-inline function arguments directly through `@*env*`, so passing that flat environment misaligned the helper's paths and generated invalid CLVM.

The initial comparison also exposed a test configuration mismatch: it disabled frontend optimization for cldb, while both command paths force frontend optimization for stepping dialects newer than 22. The regression test now mirrors the real command behavior.

## Testing
- `cargo test test_classic_codegen_mandelbrot -- --nocapture`
- `cargo test tests::compiler::cldb:: -- --nocapture`
- `python3 mandelbrot-cldb.py -sigil '*standard-cl-26-classic*'` from `resources/tests`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2f220bf9-a7cf-44ef-845c-0c5b356a48ba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2f220bf9-a7cf-44ef-845c-0c5b356a48ba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

