### PR TITLE
Translate modern com forms throughout classic codegen inputs

### DIFF
--- a/src/classic/clvm_tools/stages/stage_2/abstraction.rs
+++ b/src/classic/clvm_tools/stages/stage_2/abstraction.rs
@@ -5,8 +5,8 @@ use std::ops::Index;
 use clvm_rs::allocator::{Allocator, NodePtr, SExp};
 use clvm_rs::error::EvalErr;
 
-use crate::classic::clvm_tools::binutils::disassemble;
 use crate::classic::clvm::__type_compatibility__::bi_zero;
+use crate::classic::clvm_tools::binutils::disassemble;
 use crate::compiler::sexp::SExp as ModernSExp;
 use crate::compiler::srcloc::Srcloc;
 use crate::util::{number_from_u8, u8_from_number};
@@ -175,15 +175,12 @@ impl SExpClassicAllocator {
                     .new_pair(first.raw, rest.raw)
                     .map_err(|e| self.map_err(loc.clone(), e))?
             }
-            ModernSExp::Integer(_, value) => {
-                if *value == bi_zero() {
-                    self.allocator.new_atom(&[])
-                } else {
-                    self
-                        .allocator
-                        .new_atom(&u8_from_number(value.clone()))
-                }.map_err(|e| self.map_err(loc.clone(), e))?
+            ModernSExp::Integer(_, value) => if *value == bi_zero() {
+                self.allocator.new_atom(&[])
+            } else {
+                self.allocator.new_atom(&u8_from_number(value.clone()))
             }
+            .map_err(|e| self.map_err(loc.clone(), e))?,
             ModernSExp::QuotedString(_, _, value) | ModernSExp::Atom(_, value) => self
                 .allocator
                 .new_atom(value)

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -21,7 +21,7 @@ use crate::classic::clvm_tools::stages::stage_2::helpers::{brun, evaluate, quote
 use crate::classic::clvm_tools::stages::stage_2::module::compile_mod;
 use crate::compiler::srcloc::Srcloc;
 
-const DIAG_OUTPUT: bool = true;
+const DIAG_OUTPUT: bool = false;
 
 lazy_static! {
     static ref PASS_THROUGH_OPERATORS: HashSet<Vec<u8>> = {

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -21,10 +21,7 @@ use crate::classic::clvm_tools::stages::stage_2::helpers::{brun, evaluate, quote
 use crate::classic::clvm_tools::stages::stage_2::module::compile_mod;
 use crate::compiler::srcloc::Srcloc;
 
-use crate::classic::clvm_tools::stages::stage_2::module::Indent;
-use crate::compiler::sexp::decode_string;
-
-const DIAG_OUTPUT: bool = false;
+const DIAG_OUTPUT: bool = true;
 
 lazy_static! {
     static ref PASS_THROUGH_OPERATORS: HashSet<Vec<u8>> = {
@@ -549,10 +546,8 @@ fn find_symbol_match<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let indent = Indent::new();
     if let Some(symlist) = proper_list(allocator, symbol_table, true) {
         for sym in symlist {
-            eprintln!("{indent}sym {}", allocator.disassemble(&sym, None));
             if let Some(symdef) = proper_list(allocator, &sym, true) {
                 if symdef.is_empty() {
                     continue;
@@ -666,7 +661,6 @@ fn compile_application<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let indent = Indent::new();
     let mut compiled_args = vec![operator.clone()];
 
     let loc = allocator.loc(prog);
@@ -717,9 +711,7 @@ where
             if PASS_THROUGH_OPERATORS.contains(opbuf) || (!opbuf.is_empty() && opbuf[0] == b'_') {
                 Ok(r)
             } else {
-                eprintln!("{indent}find symbol {} in\n{indent}{}\n{indent}{}", decode_string(opbuf), allocator.disassemble(&prog, None), allocator.disassemble(&symbol_table, None));
-                find_symbol_match(allocator, opbuf, &r, symbol_table).and_then(|x| {
-                match x {
+                find_symbol_match(allocator, opbuf, &r, symbol_table).and_then(|x| match x {
                     Some(SymbolResult::Direct(v)) => Ok(v),
                     Some(SymbolResult::Matched(_symbol, value)) => {
                         let loc = allocator.loc(&value);
@@ -752,7 +744,7 @@ where
                         enlist(allocator, &[apply_atom, value, cons_enlisted])
                     }
                     None => error_result,
-                }})
+                })
             }
         }
         None => error_result,
@@ -770,10 +762,9 @@ pub fn do_com_prog<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let indent = Indent::new();
     if DIAG_OUTPUT {
         println!(
-            "START COMPILE {}: {}\n{indent}MACRO {}\n{indent}SYMBOLS {}",
+            "START COMPILE {}: {}\nMACRO {}\nSYMBOLS {}",
             from,
             allocator.disassemble(prog, None),
             allocator.disassemble(macro_lookup, None),
@@ -783,7 +774,7 @@ where
     do_com_prog_(allocator, prog, macro_lookup, symbol_table, run_program).inspect(|x| {
         if DIAG_OUTPUT {
             println!(
-                "DO_COM_PROG {}: {}\n{indent}MACRO {}\n{indent}SYMBOLS {}\n{indent}RESULT {}",
+                "DO_COM_PROG {}: {}\nMACRO {}\nSYMBOLS {}\nRESULT {}",
                 from,
                 allocator.disassemble(prog, None),
                 allocator.disassemble(macro_lookup, None),
@@ -804,7 +795,6 @@ fn do_com_prog_<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let indent = Indent::new();
     /*
      * Turn the given program `prog` into a clvm program using
      * the macros to do transformation.
@@ -860,7 +850,6 @@ where
                                         symbol_table,
                                         run_program.clone()
                                     ).and_then(|x| x.map(Ok).unwrap_or_else(|| m! {
-                                        let _ = eprintln!("{indent}compile_application {} {}\n{indent}{}", allocator.disassemble(&operator, None), allocator.disassemble(&prog, None), allocator.disassemble(&prog_rest, None));
                                         compile_application(
                                             allocator,
                                             &prog,

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -580,10 +580,15 @@ where
     Ok(None)
 }
 
+pub type SplitRestResult<A> = Option<(
+    Vec<<A as ClassicAllocator>::NodePtr>,
+    Option<<A as ClassicAllocator>::NodePtr>,
+)>;
+
 fn split_rest_tail<A: ClassicAllocator>(
     allocator: &A,
     args: &A::NodePtr,
-) -> Result<Option<(Vec<A::NodePtr>, Option<A::NodePtr>)>, ClError>
+) -> Result<SplitRestResult<A>, ClError>
 where
     A::NodePtr: Clone,
 {

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -1,4 +1,3 @@
-use std::sync::atomic::{AtomicI32, Ordering};
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::rc::Rc;
@@ -25,35 +24,6 @@ use crate::classic::clvm_tools::stages::stage_2::inline::{
 use crate::classic::clvm_tools::stages::stage_2::optimize::optimize_sexp;
 use crate::classic::clvm_tools::stages::stage_2::reader::process_embed_file;
 use crate::compiler::srcloc::Srcloc;
-
-lazy_static! {
-    pub static ref INDENT: AtomicI32 = AtomicI32::new(0);
-}
-
-pub struct Indent;
-
-impl Indent {
-    pub fn new() -> Self {
-        INDENT.fetch_add(1, Ordering::Relaxed);
-        Indent
-    }
-}
-
-impl std::fmt::Display for Indent {
-    fn fmt(&self, fmt: &'_ mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        let indent = INDENT.fetch_add(0, Ordering::Relaxed);
-        for i in 0..indent {
-            write!(fmt, "  ")?;
-        }
-        Ok(())
-    }
-}
-
-impl Drop for Indent {
-    fn drop(&mut self) {
-        INDENT.fetch_add(-1, Ordering::Relaxed);
-    }
-}
 
 lazy_static! {
     pub static ref MAIN_NAME: String = "".to_string();
@@ -599,7 +569,6 @@ fn compile_mod_stage_1<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let indent = Indent::new();
     // stage 1: collect up names of globals (functions, constants, macros)
     m! {
         let mut functions = HashMap::new();
@@ -632,10 +601,10 @@ where
                 }
 
                 let main_local_arguments = alist[0].clone();
-                eprintln!("{indent}main_local_arguments {}", allocator.disassemble(&alist[0], None));
+                eprintln!("main_local_arguments {}", allocator.disassemble(&alist[0], None));
 
                 for arg in alist.iter().take(alist.len()-1).skip(1) {
-                    eprintln!("{indent}parse_mod_sexp {}", allocator.disassemble(arg, None));
+                    eprintln!("parse_mod_sexp {}", allocator.disassemble(arg, None));
                     parse_mod_sexp(
                         allocator,
                         arg,
@@ -1095,11 +1064,9 @@ pub fn compile_mod<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let indent = Indent::new();
-
     // Deal with the "mod" keyword.
-    eprintln!("{indent}compile_mod {}", allocator.disassemble(args, None));
-    eprintln!("{indent}symbol_table {}", allocator.disassemble(symbol_table, None));
+    eprintln!("compile_mod {}", allocator.disassemble(args, None));
+    eprintln!("symbol_table {}", allocator.disassemble(symbol_table, None));
     let loc = allocator.loc(macro_lookup);
     let produce_extra_info_prog = assemble(allocator.allocator(), "(_symbols_extra_info)")
         .map_err(|e| ClError(loc.clone(), e))?;

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -601,10 +601,8 @@ where
                 }
 
                 let main_local_arguments = alist[0].clone();
-                eprintln!("main_local_arguments {}", allocator.disassemble(&alist[0], None));
 
                 for arg in alist.iter().take(alist.len()-1).skip(1) {
-                    eprintln!("parse_mod_sexp {}", allocator.disassemble(arg, None));
                     parse_mod_sexp(
                         allocator,
                         arg,
@@ -1057,7 +1055,7 @@ pub fn compile_mod<A: ClassicAllocator>(
     allocator: &mut A,
     args: &A::NodePtr,
     macro_lookup: &A::NodePtr,
-    symbol_table: &A::NodePtr,
+    _symbol_table: &A::NodePtr,
     run_program: Rc<dyn TRunProgram>,
     _level: usize,
 ) -> Result<A::NodePtr, ClError>
@@ -1065,8 +1063,6 @@ where
     A::NodePtr: Clone,
 {
     // Deal with the "mod" keyword.
-    eprintln!("compile_mod {}", allocator.disassemble(args, None));
-    eprintln!("symbol_table {}", allocator.disassemble(symbol_table, None));
     let loc = allocator.loc(macro_lookup);
     let produce_extra_info_prog = assemble(allocator.allocator(), "(_symbols_extra_info)")
         .map_err(|e| ClError(loc.clone(), e))?;

--- a/src/classic/clvm_tools/stages/stage_2/operators.rs
+++ b/src/classic/clvm_tools/stages/stage_2/operators.rs
@@ -18,9 +18,7 @@ use crate::classic::clvm::OPERATORS_LATEST_VERSION;
 use crate::classic::clvm::sexp::proper_list;
 use crate::classic::clvm::{keyword_from_atom, keyword_to_atom};
 
-use crate::classic::clvm_tools::binutils::{
-    assemble_from_ir, disassemble_to_ir_with_kw,
-};
+use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble_to_ir_with_kw};
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::ir::writer::write_ir_to_stream;
 use crate::classic::clvm_tools::sha256tree::TreeHash;

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -1306,9 +1306,6 @@ pub fn should_inline_let(
     opts: Rc<dyn CompilerOpts>,
     inline_hint: &Option<LetFormInlineHint>,
 ) -> bool {
-    if opts.dialect().classic_codegen {
-        return false;
-    }
     let match_none = opts.module_phase().is_none();
     let want_inline = matches!(inline_hint, Some(LetFormInlineHint::Inline(_)));
     want_inline || (match_none && inline_hint.is_none())
@@ -1560,6 +1557,7 @@ pub fn hoist_body_let_binding(
         BodyForm::Let(LetFormKind::Parallel, letdata) => {
             let mut out_defuns = Vec::new();
             let defun_name = gensym("letbinding".as_bytes().to_vec());
+            let force_non_inline = opts.dialect().classic_codegen && outer_context.is_some();
 
             let mut revised_bindings = Vec::new();
             for b in letdata.bindings.iter() {
@@ -1587,6 +1585,15 @@ pub fn hoist_body_let_binding(
                 revised_bindings.to_vec(),
                 letdata.body.clone(),
             );
+            let generated_defun = if force_non_inline {
+                if let HelperForm::Defun(_, defun) = generated_defun {
+                    HelperForm::Defun(false, defun)
+                } else {
+                    unreachable!()
+                }
+            } else {
+                generated_defun
+            };
             out_defuns.push(generated_defun);
 
             let mut let_args = generate_let_args(letdata.loc.clone(), revised_bindings.to_vec());

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -1306,6 +1306,9 @@ pub fn should_inline_let(
     opts: Rc<dyn CompilerOpts>,
     inline_hint: &Option<LetFormInlineHint>,
 ) -> bool {
+    if opts.dialect().classic_codegen {
+        return false;
+    }
     let match_none = opts.module_phase().is_none();
     let want_inline = matches!(inline_hint, Some(LetFormInlineHint::Inline(_)));
     want_inline || (match_none && inline_hint.is_none())

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1,6 +1,5 @@
 use num_bigint::ToBigInt;
 
-use std::sync::atomic::{AtomicI32, Ordering};
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
@@ -29,9 +28,9 @@ use crate::compiler::clvm::{convert_to_clvm_rs, run, sha256tree, NewStyleIntConv
 use crate::compiler::codegen::{codegen, hoist_body_let_binding, process_helper_let_bindings};
 use crate::compiler::comptypes::{
     BodyForm, CompileErr, CompileForm, CompileModuleComponent, CompileModuleOutput, CompilerOpts,
-    CompilerOutput, ConstantKind, DefunData, DefmacData, Export, FrontendOutput, HelperForm, ImportLongName,
-    IncludeDesc, IncludeProcessType, ModulePhase, PrimaryCodegen, StandalonePhaseInfo,
-    SyntheticType,
+    CompilerOutput, ConstantKind, DefconstData, DefmacData, DefunData, Export, FrontendOutput,
+    HelperForm, ImportLongName, IncludeDesc, IncludeProcessType, ModulePhase, NamespaceData,
+    PrimaryCodegen, StandalonePhaseInfo, SyntheticType,
 };
 use crate::compiler::dialect::{AcceptedDialect, KNOWN_DIALECTS};
 use crate::compiler::frontend::frontend;
@@ -44,35 +43,6 @@ use crate::compiler::sexp::{decode_string, enlist, parse_sexp_flags, SExp};
 use crate::compiler::srcloc::Srcloc;
 use crate::compiler::{BasicCompileContext, CompileContextWrapper};
 use crate::util::Number;
-
-lazy_static! {
-    pub static ref INDENT: AtomicI32 = AtomicI32::new(0);
-}
-
-struct Indent;
-
-impl Indent {
-    fn new() -> Self {
-        INDENT.fetch_add(1, Ordering::Relaxed);
-        Indent
-    }
-}
-
-impl std::fmt::Display for Indent {
-    fn fmt(&self, fmt: &'_ mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        let indent = INDENT.fetch_add(0, Ordering::Relaxed);
-        for i in 0..indent {
-            write!(fmt, "  ")?;
-        }
-        Ok(())
-    }
-}
-
-impl Drop for Indent {
-    fn drop(&mut self) {
-        INDENT.fetch_add(-1, Ordering::Relaxed);
-    }
-}
 
 pub const SHA256TREE_PROGRAM_CLVM: &str = "(2 (1 2 (3 (7 5) (1 11 (1 . 2) (2 2 (4 2 (4 9 ()))) (2 2 (4 2 (4 13 ())))) (1 11 (1 . 1) 5)) 1) (4 (1 2 (3 (7 5) (1 11 (1 . 2) (2 2 (4 2 (4 9 ()))) (2 2 (4 2 (4 13 ())))) (1 11 (1 . 1) 5)) 1) 1))";
 
@@ -193,42 +163,37 @@ pub fn expand_com_forms_expr(
     opts: Rc<dyn CompilerOpts>,
     body: Rc<BodyForm>,
 ) -> Result<Rc<BodyForm>, CompileErr> {
-    let indent = Indent::new();
     if let BodyForm::Call(l, c, tail) = &*body {
         if c.is_empty() {
             return Ok(body);
         }
 
         if let BodyForm::Value(atom) = &*c[0] {
-            if atom.atomize() == SExp::Atom(atom.loc(), b"com".to_vec()) {
-                // Is a com form.
-                eprintln!("{indent}com {}", c[1].to_sexp());
-                return Ok(Rc::new(BodyForm::Call(l.clone(), vec![
-                    Rc::new(BodyForm::Value(SExp::Atom(c[0].loc(), b"function".to_vec()))),
-                    c[1].clone(),
-                ], None)));
+            if c.len() == 2 && atom.atomize() == SExp::Atom(atom.loc(), b"com".to_vec()) {
+                return Ok(Rc::new(BodyForm::Call(
+                    l.clone(),
+                    vec![
+                        Rc::new(BodyForm::Value(SExp::Atom(
+                            c[0].loc(),
+                            b"function".to_vec(),
+                        ))),
+                        c[1].clone(),
+                    ],
+                    None,
+                )));
             }
         }
 
         let mut call_args = vec![c[0].clone()];
         for item in c.iter().skip(1) {
-            call_args.push(expand_com_forms_expr(
-                context,
-                opts.clone(),
-                item.clone()
-            )?);
+            call_args.push(expand_com_forms_expr(context, opts.clone(), item.clone())?);
         }
 
-        let new_tail =
-            if let Some(t) = &tail {
-                Some(expand_com_forms_expr(
-                    context,
-                    opts,
-                    t.clone()
-                )?)
-            } else {
-                None
-            };
+        let new_tail = if let Some(t) = &tail {
+            Some(expand_com_forms_expr(context, opts, t.clone())?)
+        } else {
+            None
+        };
 
         return Ok(Rc::new(BodyForm::Call(l.clone(), call_args, new_tail)));
     }
@@ -236,26 +201,63 @@ pub fn expand_com_forms_expr(
     Ok(body)
 }
 
-/// Expand compiler forms using the modern evaluator before handing a program to
-/// a backend that does not implement modern compiler-form semantics.
+fn expand_com_forms_helper(
+    context: &mut BasicCompileContext,
+    opts: Rc<dyn CompilerOpts>,
+    helper: &HelperForm,
+) -> Result<HelperForm, CompileErr> {
+    match helper {
+        HelperForm::Defconstant(defconst) => Ok(HelperForm::Defconstant(DefconstData {
+            body: expand_com_forms_expr(context, opts, defconst.body.clone())?,
+            ..defconst.clone()
+        })),
+        HelperForm::Defmacro(defmacro) => Ok(HelperForm::Defmacro(DefmacData {
+            program: Rc::new(expand_com_forms(
+                context,
+                opts,
+                defmacro.program.as_ref().clone(),
+            )?),
+            ..defmacro.clone()
+        })),
+        HelperForm::Defun(inline, defun) => Ok(HelperForm::Defun(
+            *inline,
+            Box::new(DefunData {
+                body: expand_com_forms_expr(context, opts, defun.body.clone())?,
+                ..*defun.clone()
+            }),
+        )),
+        HelperForm::Defnamespace(namespace) => {
+            let helpers = namespace
+                .helpers
+                .iter()
+                .map(|helper| expand_com_forms_helper(context, opts.clone(), helper))
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(HelperForm::Defnamespace(Box::new(NamespaceData {
+                helpers,
+                ..*namespace.clone()
+            })))
+        }
+        HelperForm::Defnsref(_) => Ok(helper.clone()),
+    }
+}
+
+/// Translate modern `com` forms for a backend that only implements `function`.
 pub fn expand_com_forms(
     context: &mut BasicCompileContext,
     opts: Rc<dyn CompilerOpts>,
     compileform: CompileForm,
 ) -> Result<CompileForm, CompileErr> {
-    let helpers = compileform.helpers.iter().map(|h| {
-        todo!();
-    });
-
-    let new_expr = expand_com_forms_expr(
-        context,
-        opts,
-        compileform.exp.clone()
-    )?;
+    let helpers = compileform
+        .helpers
+        .iter()
+        .map(|helper| expand_com_forms_helper(context, opts.clone(), helper))
+        .collect::<Result<Vec<_>, _>>()?;
+    let exp = expand_com_forms_expr(context, opts, compileform.exp.clone())?;
 
     Ok(CompileForm {
-        exp: new_expr,
-        .. compileform
+        helpers,
+        exp,
+        ..compileform
     })
 }
 
@@ -266,16 +268,13 @@ pub fn finish_compilation(
     opts: Rc<dyn CompilerOpts>,
     p2: CompileForm,
 ) -> Result<SExp, CompileErr> {
-    let indent = Indent::new();
     let p3 = context.post_desugar_optimization(opts.clone(), p2)?;
 
     if opts.dialect().classic_codegen {
         let mut modern_dialect = opts.dialect();
         modern_dialect.classic_codegen = false;
         let modern_opts = opts.set_dialect(modern_dialect);
-        eprintln!("{indent}p3 {}", p3.to_sexp());
         let p4 = expand_com_forms(context, modern_opts, p3)?;
-        eprintln!("{indent}expanded {}", p4.to_sexp());
         return classic_codegen(opts, p4);
     }
 
@@ -291,7 +290,7 @@ pub fn finish_compilation(
 ///
 /// The classic compiler's normal final optimization is part of its code
 /// generation contract. No modern optimization hooks run on this path.
-fn classic_codegen(opts: Rc<dyn CompilerOpts>, mut program: CompileForm) -> Result<SExp, CompileErr> {
+fn classic_codegen(opts: Rc<dyn CompilerOpts>, program: CompileForm) -> Result<SExp, CompileErr> {
     let language_flags = if opts.dialect().extra_numeric_constants {
         NEW_BIT_CONSTANTS
     } else {
@@ -306,27 +305,13 @@ fn classic_codegen(opts: Rc<dyn CompilerOpts>, mut program: CompileForm) -> Resu
     runner.set_compiler_opts(Some(opts.clone()));
 
     let mut allocator = SExpClassicAllocator::new();
-    let x_atom = SExp::Atom(program.loc(), b"X".to_vec());
-    let program_args = Rc::new(SExp::Cons(
-        program.loc(),
-        Rc::new(x_atom.clone()),
-        Rc::new(SExp::Nil(program.loc())),
-    ));
-    let cons = Rc::new(BodyForm::Value(SExp::Integer(program.loc(), 4_u32.to_bigint().unwrap())));
     let macro_lookup = default_macro_lookup(&mut allocator, runner.clone());
     let nil = allocator
         .import(program.loc(), clvm_rs::allocator::NodePtr::NIL)
         .map_err(|e| CompileErr(e.0, e.1.to_string()))?;
-    let final_program = Rc::new(SExp::Cons(
-        program.loc(),
-        Rc::new(SExp::Atom(program.loc(), b"mod".to_vec())),
-        program.to_sexp()
-    ));
-
     let args = allocator
         .from_sexp(program.to_sexp())
         .map_err(|e| CompileErr(e.0, e.1.to_string()))?;
-    // eprintln!("compile_mod {}", final_program);
     let generated = compile_mod(
         &mut allocator,
         &args,
@@ -360,7 +345,6 @@ pub fn compile_from_compileform(
     opts: Rc<dyn CompilerOpts>,
     p0: CompileForm,
 ) -> Result<SExp, CompileErr> {
-    let indent = Indent::new();
     let p1 =
         if opts.dialect().classic_codegen {
             p0
@@ -368,11 +352,9 @@ pub fn compile_from_compileform(
             context.frontend_optimization(opts.clone(), p0)?
         };
 
-    eprintln!("{indent}frontend_opt {}", p1.to_sexp());
     // Resolve includes, convert program source to lexemes
     let p2 = do_desugar(opts.clone(), &p1)?;
 
-    eprintln!("{indent}desugared {}", p2.to_sexp());
     finish_compilation(context, opts, p2)
 }
 

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -159,7 +159,6 @@ pub fn do_desugar(
 }
 
 pub fn expand_com_forms_expr(
-    context: &mut BasicCompileContext,
     opts: Rc<dyn CompilerOpts>,
     body: Rc<BodyForm>,
 ) -> Result<Rc<BodyForm>, CompileErr> {
@@ -186,11 +185,11 @@ pub fn expand_com_forms_expr(
 
         let mut call_args = vec![c[0].clone()];
         for item in c.iter().skip(1) {
-            call_args.push(expand_com_forms_expr(context, opts.clone(), item.clone())?);
+            call_args.push(expand_com_forms_expr(opts.clone(), item.clone())?);
         }
 
         let new_tail = if let Some(t) = &tail {
-            Some(expand_com_forms_expr(context, opts, t.clone())?)
+            Some(expand_com_forms_expr(opts, t.clone())?)
         } else {
             None
         };
@@ -208,7 +207,7 @@ fn expand_com_forms_helper(
 ) -> Result<HelperForm, CompileErr> {
     match helper {
         HelperForm::Defconstant(defconst) => Ok(HelperForm::Defconstant(DefconstData {
-            body: expand_com_forms_expr(context, opts, defconst.body.clone())?,
+            body: expand_com_forms_expr(opts, defconst.body.clone())?,
             ..defconst.clone()
         })),
         HelperForm::Defmacro(defmacro) => Ok(HelperForm::Defmacro(DefmacData {
@@ -222,7 +221,7 @@ fn expand_com_forms_helper(
         HelperForm::Defun(inline, defun) => Ok(HelperForm::Defun(
             *inline,
             Box::new(DefunData {
-                body: expand_com_forms_expr(context, opts, defun.body.clone())?,
+                body: expand_com_forms_expr(opts, defun.body.clone())?,
                 ..*defun.clone()
             }),
         )),
@@ -252,7 +251,7 @@ pub fn expand_com_forms(
         .iter()
         .map(|helper| expand_com_forms_helper(context, opts.clone(), helper))
         .collect::<Result<Vec<_>, _>>()?;
-    let exp = expand_com_forms_expr(context, opts, compileform.exp.clone())?;
+    let exp = expand_com_forms_expr(opts, compileform.exp.clone())?;
 
     Ok(CompileForm {
         helpers,

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -272,9 +272,8 @@ pub fn finish_compilation(
         let mut modern_dialect = opts.dialect();
         modern_dialect.classic_codegen = false;
         let modern_opts = opts.set_dialect(modern_dialect);
-        let p3 = context.post_desugar_optimization(modern_opts.clone(), p2)?;
-        let p4 = expand_com_forms(context, modern_opts, p3)?;
-        return classic_codegen(opts, p4);
+        let p3 = expand_com_forms(context, modern_opts, p2)?;
+        return classic_codegen(opts, p3);
     }
 
     let p3 = context.post_desugar_optimization(opts.clone(), p2)?;

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -45,7 +45,34 @@ use crate::compiler::srcloc::Srcloc;
 use crate::compiler::{BasicCompileContext, CompileContextWrapper};
 use crate::util::Number;
 
-use crate::classic::clvm_tools::stages::stage_2::module::Indent;
+lazy_static! {
+    pub static ref INDENT: AtomicI32 = AtomicI32::new(0);
+}
+
+struct Indent;
+
+impl Indent {
+    fn new() -> Self {
+        INDENT.fetch_add(1, Ordering::Relaxed);
+        Indent
+    }
+}
+
+impl std::fmt::Display for Indent {
+    fn fmt(&self, fmt: &'_ mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        let indent = INDENT.fetch_add(0, Ordering::Relaxed);
+        for i in 0..indent {
+            write!(fmt, "  ")?;
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Indent {
+    fn drop(&mut self) {
+        INDENT.fetch_add(-1, Ordering::Relaxed);
+    }
+}
 
 pub const SHA256TREE_PROGRAM_CLVM: &str = "(2 (1 2 (3 (7 5) (1 11 (1 . 2) (2 2 (4 2 (4 9 ()))) (2 2 (4 2 (4 13 ())))) (1 11 (1 . 1) 5)) 1) (4 (1 2 (3 (7 5) (1 11 (1 . 2) (2 2 (4 2 (4 9 ()))) (2 2 (4 2 (4 13 ())))) (1 11 (1 . 1) 5)) 1) 1))";
 
@@ -917,16 +944,17 @@ pub fn compile_pre_forms(
 
     let frontend_opts = if opts.dialect().classic_codegen {
         let mut modern_dialect = opts.dialect();
-        opts.set_dialect(modern_dialect).set_frontend_opt(false)
+        modern_dialect.classic_codegen = false;
+        opts.set_dialect(modern_dialect)
     } else {
         opts.clone()
     };
-    let p0 = frontend(frontend_opts.clone(), pre_forms)?;
+    let p0 = frontend(frontend_opts, pre_forms)?;
 
     match p0 {
         FrontendOutput::CompileForm(p0) => Ok(CompilerOutput::Program(
             p0.include_forms.clone(),
-            compile_from_compileform(context, frontend_opts, p0)?,
+            compile_from_compileform(context, opts, p0)?,
         )),
         FrontendOutput::Module(mut cf, exports) => {
             add_main_fingerprint(&mut cf, pre_forms);

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -15,7 +15,7 @@ use crate::classic::clvm::__type_compatibility__::{bi_one, bi_zero};
 use crate::classic::clvm_tools::ir::r#type::NEW_BIT_CONSTANTS;
 use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::{
-    ASExp, BufCarrier, ClassicAllocator, SExpClassicAllocator, SExpNode,
+    ASExp, BufCarrier, ClassicAllocator, SExpClassicAllocator,
 };
 use crate::classic::clvm_tools::stages::stage_2::defaults::default_macro_lookup;
 use crate::classic::clvm_tools::stages::stage_2::module::compile_mod;
@@ -268,15 +268,16 @@ pub fn finish_compilation(
     opts: Rc<dyn CompilerOpts>,
     p2: CompileForm,
 ) -> Result<SExp, CompileErr> {
-    let p3 = context.post_desugar_optimization(opts.clone(), p2)?;
-
     if opts.dialect().classic_codegen {
         let mut modern_dialect = opts.dialect();
         modern_dialect.classic_codegen = false;
         let modern_opts = opts.set_dialect(modern_dialect);
+        let p3 = context.post_desugar_optimization(modern_opts.clone(), p2)?;
         let p4 = expand_com_forms(context, modern_opts, p3)?;
         return classic_codegen(opts, p4);
     }
+
+    let p3 = context.post_desugar_optimization(opts.clone(), p2)?;
 
     // generate code from AST, optionally with optimization
     let generated = codegen(context, opts.clone(), &p3)?;
@@ -345,12 +346,11 @@ pub fn compile_from_compileform(
     opts: Rc<dyn CompilerOpts>,
     p0: CompileForm,
 ) -> Result<SExp, CompileErr> {
-    let p1 =
-        if opts.dialect().classic_codegen {
-            p0
-        } else {
-            context.frontend_optimization(opts.clone(), p0)?
-        };
+    let p1 = if opts.dialect().classic_codegen {
+        p0
+    } else {
+        context.frontend_optimization(opts.clone(), p0)?
+    };
 
     // Resolve includes, convert program source to lexemes
     let p2 = do_desugar(opts.clone(), &p1)?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- preserve the modern-frontend/classic-backend option split
- translate modern `com` forms to classic `function` forms throughout helper bodies and the module expression
- bypass modern deinline size analysis on the classic backend path
- keep nested classic let helpers non-inline while retaining top-level let inlining
- remove temporary compiler tracing

## Cause
The failure is not a semantic difference between a simple modern `com` and classic `function`. It occurs when a `com` branch contains a hoisted `let` helper:

1. Modern deinline analysis runs code generation over classic-path helper/environment shapes.
2. It may compile a function body without the sibling `letbinding_...` helper (`unknown operator`) or choose to inline that helper.
3. A nested inlined helper reconstructs the enclosing classic function argument tree as `(c X (c Y ...))`. Classic inline destructuring emits that dynamic expression in operator position, producing the observed `InvalidOperatorArg` for `((X)...)`.
4. The test harness then runs compiler error text as if it were CLVM, which previously obscured the compile error as `path into atom ()`.

The diagnostic commit also passed classic-codegen options into the modern frontend, independently causing the `if` smoke regression. This change restores the option split, translates all `com` occurrences structurally, skips the incompatible deinline decision, and emits nested classic let helpers as regular functions so their reconstructed environment is evaluated as an argument.

## Tests
- `cargo test test_equivalence -- --nocapture`
- `cargo test test_modern_frontend_with_classic_codegen_semantics -- --nocapture`
- `cargo check --all-targets`
- full `cargo test` passed all functional tests reached; the pre-existing performance suite was stopped after it ran without output for over 11 minutes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e27b0ffe-7f20-4882-becc-a9d9a49e16da?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e27b0ffe-7f20-4882-becc-a9d9a49e16da&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

