### PR TITLE
Preserve locations across classic CLVM evaluation

### DIFF
--- a/src/classic/clvm_tools/clvmc.rs
+++ b/src/classic/clvm_tools/clvmc.rs
@@ -11,7 +11,8 @@ use crate::classic::clvm_tools::binutils::{assemble_from_ir, disassemble};
 use crate::classic::clvm_tools::ir::r#type::NEW_BIT_CONSTANTS;
 use crate::classic::clvm_tools::ir::reader::read_ir;
 use crate::classic::clvm_tools::stages::run;
-use crate::classic::clvm_tools::stages::stage_0::{DefaultProgramRunner, TRunProgram};
+use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
+use crate::classic::clvm_tools::stages::stage_2::abstraction::ClassicAllocator;
 use crate::classic::clvm_tools::stages::stage_2::operators::run_program_for_search_paths;
 
 use crate::classic::platform::distutils::dep_util::newer;
@@ -152,8 +153,9 @@ pub fn compile_clvm_text_maybe_opt(
         if classic_with_opts {
             run_program.set_compiler_opts(Some(opts));
         }
-        let run_program_output =
-            run_program.run_program(allocator, compile_invoke_code, input_sexp, None)?;
+        let run_program_output = allocator
+            .run_program(run_program, &compile_invoke_code, &input_sexp, None)
+            .map_err(|err| CompileError::from(err.1))?;
         Ok(run_program_output.1)
     }
 }

--- a/src/classic/clvm_tools/debug.rs
+++ b/src/classic/clvm_tools/debug.rs
@@ -119,13 +119,12 @@ where
     let mut map_result: Vec<A::NodePtr> = Vec::new();
 
     for (k, v) in constants_lookup.iter() {
-        let v_export = allocator.export(v);
         let vloc = allocator.loc(v);
-        let run_result = run_program
-            .run_program(allocator.allocator(), v_export, NodePtr::NIL, None)
-            .map_err(|e| allocator.map_err(vloc.clone(), e))?;
+        let nil = allocator.import(vloc.clone(), NodePtr::NIL)?;
+        let run_result = allocator.run_program(run_program.clone(), v, &nil, None)?.1;
 
-        let sha256 = sha256tree(allocator.allocator(), run_result.1).hex();
+        let run_result = allocator.export(&run_result);
+        let sha256 = sha256tree(allocator.allocator(), run_result).hex();
         let sha_atom = allocator.new_atom(vloc.clone(), sha256.as_bytes())?;
         let name_atom = allocator.new_atom(vloc.clone(), &k.clone())?;
 

--- a/src/classic/clvm_tools/stages/stage_2/abstraction.rs
+++ b/src/classic/clvm_tools/stages/stage_2/abstraction.rs
@@ -378,7 +378,7 @@ impl ClassicAllocator for SExpClassicAllocator {
 
 #[cfg(test)]
 mod tests {
-    use super::{ClassicAllocator, SExpClassicAllocator};
+    use super::{BufCarrier, ClassicAllocator, SExpClassicAllocator};
     use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
     use crate::compiler::sexp::{enlist, SExp};
     use crate::compiler::srcloc::Srcloc;

--- a/src/classic/clvm_tools/stages/stage_2/abstraction.rs
+++ b/src/classic/clvm_tools/stages/stage_2/abstraction.rs
@@ -1,12 +1,16 @@
+use std::collections::HashMap;
 use std::rc::Rc;
 
 use std::ops::Index;
 
 use clvm_rs::allocator::{Allocator, NodePtr, SExp};
+use clvm_rs::cost::Cost;
 use clvm_rs::error::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::bi_zero;
 use crate::classic::clvm_tools::binutils::disassemble;
+use crate::classic::clvm_tools::stages::stage_0::{RunProgramOption, TRunProgram};
+use crate::compiler::debug::{build_swap_table_mut, relabel};
 use crate::compiler::sexp::SExp as ModernSExp;
 use crate::compiler::srcloc::Srcloc;
 use crate::util::{number_from_u8, u8_from_number};
@@ -70,6 +74,17 @@ pub trait ClassicAllocator {
     ) -> Result<Self::NodePtr, ClError>;
     fn import(&mut self, loc: Srcloc, node: NodePtr) -> Result<Self::NodePtr, ClError>;
     fn export(&self, node: &Self::NodePtr) -> NodePtr;
+    /// Execute via `TRunProgram`, retaining this allocator's node representation.
+    ///
+    /// Location-aware allocators may use an execution-scoped tree-hash cache to
+    /// restore metadata on result subtrees which are unchanged by evaluation.
+    fn run_program(
+        &mut self,
+        runner: Rc<dyn TRunProgram>,
+        program: &Self::NodePtr,
+        args: &Self::NodePtr,
+        option: Option<RunProgramOption>,
+    ) -> Result<(Cost, Self::NodePtr), ClError>;
 }
 
 thread_local! {
@@ -127,6 +142,19 @@ impl ClassicAllocator for Allocator {
     fn export(&self, node: &Self::NodePtr) -> NodePtr {
         *node
     }
+    fn run_program(
+        &mut self,
+        runner: Rc<dyn TRunProgram>,
+        program: &Self::NodePtr,
+        args: &Self::NodePtr,
+        option: Option<RunProgramOption>,
+    ) -> Result<(Cost, Self::NodePtr), ClError> {
+        let loc = self.loc(program);
+        runner
+            .run_program(self, *program, *args, option)
+            .map(|result| (result.0, result.1))
+            .map_err(|err| ClError(loc, err))
+    }
 }
 
 /// A stage-2 node backed by the compiler's location-aware S-expression.
@@ -149,6 +177,7 @@ impl std::fmt::Display for SExpNode {
 /// Adapts modern compiler S-expressions to the classic stage-2 compiler.
 pub struct SExpClassicAllocator {
     allocator: Allocator,
+    run_program_cache: HashMap<String, ModernSExp>,
 }
 
 impl Default for SExpClassicAllocator {
@@ -161,6 +190,7 @@ impl SExpClassicAllocator {
     pub fn new() -> Self {
         Self {
             allocator: Allocator::new(),
+            run_program_cache: HashMap::new(),
         }
     }
 
@@ -303,5 +333,137 @@ impl ClassicAllocator for SExpClassicAllocator {
 
     fn export(&self, node: &Self::NodePtr) -> NodePtr {
         node.raw
+    }
+
+    fn run_program(
+        &mut self,
+        runner: Rc<dyn TRunProgram>,
+        program: &Self::NodePtr,
+        args: &Self::NodePtr,
+        option: Option<RunProgramOption>,
+    ) -> Result<(Cost, Self::NodePtr), ClError> {
+        self.run_program_cache.clear();
+        build_swap_table_mut(&mut self.run_program_cache, program.sexp.as_ref());
+        build_swap_table_mut(&mut self.run_program_cache, args.sexp.as_ref());
+
+        let loc = self.loc(program);
+        let result = runner.run_program(&mut self.allocator, program.raw, args.raw, option);
+        let result = match result {
+            Ok(result) => result,
+            Err(err) => {
+                self.run_program_cache.clear();
+                return Err(ClError(loc, err));
+            }
+        };
+
+        let imported = match self.import(loc, result.1) {
+            Ok(imported) => imported,
+            Err(err) => {
+                self.run_program_cache.clear();
+                return Err(err);
+            }
+        };
+        let relabeled = relabel(&self.run_program_cache, imported.sexp.as_ref());
+        self.run_program_cache.clear();
+
+        Ok((
+            result.0,
+            SExpNode {
+                sexp: Rc::new(relabeled),
+                raw: result.1,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClassicAllocator, SExpClassicAllocator};
+    use crate::classic::clvm_tools::stages::stage_0::DefaultProgramRunner;
+    use crate::compiler::sexp::{enlist, SExp};
+    use crate::compiler::srcloc::Srcloc;
+    use num_bigint::ToBigInt;
+    use std::rc::Rc;
+
+    fn quote(loc: Srcloc, value: Rc<SExp>) -> Rc<SExp> {
+        Rc::new(SExp::Cons(
+            loc.clone(),
+            Rc::new(SExp::Integer(loc, 1_i32.to_bigint().unwrap())),
+            value,
+        ))
+    }
+
+    #[test]
+    fn run_program_restores_matching_locations_and_clears_its_cache() {
+        let file = Rc::new("*run-program-cache-test*".to_string());
+        let program_loc = Srcloc::new(file.clone(), 1, 1);
+        let value_loc = Srcloc::new(file.clone(), 1, 5);
+        let rest_loc = Srcloc::new(file.clone(), 1, 10);
+        let args_loc = Srcloc::new(file.clone(), 1, 12);
+
+        let value = Rc::new(SExp::Atom(value_loc.clone(), b"value".to_vec()));
+        let rest = Rc::new(SExp::Atom(rest_loc.clone(), b"rest".to_vec()));
+        let program = Rc::new(enlist(
+            program_loc.clone(),
+            &[
+                Rc::new(SExp::Integer(
+                    program_loc.clone(),
+                    4_i32.to_bigint().unwrap(),
+                )),
+                quote(value_loc.clone(), value),
+                quote(rest_loc.clone(), rest),
+            ],
+        ));
+
+        let mut allocator = SExpClassicAllocator::new();
+        let program = allocator.from_sexp(program).unwrap();
+        let args = allocator.from_sexp(Rc::new(SExp::Nil(args_loc))).unwrap();
+        let result = allocator
+            .run_program(Rc::new(DefaultProgramRunner::new()), &program, &args, None)
+            .unwrap()
+            .1;
+
+        match result.sexp.as_ref() {
+            SExp::Cons(loc, first, rest) => {
+                assert_eq!(*loc, program_loc);
+                assert_eq!(first.loc(), value_loc);
+                assert_eq!(rest.loc(), rest_loc);
+            }
+            result => panic!("expected cons result, got {result}"),
+        }
+
+        let second_program_loc = Srcloc::new(file.clone(), 2, 1);
+        let left_loc = Srcloc::new(file.clone(), 2, 8);
+        let right_loc = Srcloc::new(file, 2, 14);
+        let second_program = Rc::new(enlist(
+            second_program_loc.clone(),
+            &[
+                Rc::new(SExp::Integer(
+                    second_program_loc.clone(),
+                    14_i32.to_bigint().unwrap(),
+                )),
+                quote(
+                    left_loc.clone(),
+                    Rc::new(SExp::Atom(left_loc, b"val".to_vec())),
+                ),
+                quote(
+                    right_loc.clone(),
+                    Rc::new(SExp::Atom(right_loc, b"ue".to_vec())),
+                ),
+            ],
+        ));
+        let second_program = allocator.from_sexp(second_program).unwrap();
+        let second_result = allocator
+            .run_program(
+                Rc::new(DefaultProgramRunner::new()),
+                &second_program,
+                &args,
+                None,
+            )
+            .unwrap()
+            .1;
+
+        assert_eq!(allocator.atom(&second_result).as_ref(), b"value");
+        assert_eq!(second_result.sexp.loc(), second_program_loc);
     }
 }

--- a/src/classic/clvm_tools/stages/stage_2/abstraction.rs
+++ b/src/classic/clvm_tools/stages/stage_2/abstraction.rs
@@ -7,10 +7,9 @@ use clvm_rs::allocator::{Allocator, NodePtr, SExp};
 use clvm_rs::cost::Cost;
 use clvm_rs::error::EvalErr;
 
-use crate::classic::clvm::__type_compatibility__::bi_zero;
+use crate::classic::clvm::__type_compatibility__::{bi_zero, sha256, Bytes, BytesFromType};
 use crate::classic::clvm_tools::binutils::disassemble;
 use crate::classic::clvm_tools::stages::stage_0::{RunProgramOption, TRunProgram};
-use crate::compiler::debug::{build_swap_table_mut, relabel};
 use crate::compiler::sexp::SExp as ModernSExp;
 use crate::compiler::srcloc::Srcloc;
 use crate::util::{number_from_u8, u8_from_number};
@@ -177,7 +176,7 @@ impl std::fmt::Display for SExpNode {
 /// Adapts modern compiler S-expressions to the classic stage-2 compiler.
 pub struct SExpClassicAllocator {
     allocator: Allocator,
-    run_program_cache: HashMap<String, ModernSExp>,
+    run_program_cache: HashMap<String, Srcloc>,
 }
 
 impl Default for SExpClassicAllocator {
@@ -217,6 +216,88 @@ impl SExpClassicAllocator {
                 .map_err(|e| self.map_err(loc.clone(), e))?,
         };
         Ok(SExpNode { sexp, raw })
+    }
+
+    fn atom_tree_hash(&self, node: NodePtr) -> Bytes {
+        sha256(
+            Bytes::new(Some(BytesFromType::Raw(vec![1]))).concat(&Bytes::new(Some(
+                BytesFromType::Raw(self.allocator.atom(node).as_ref().to_vec()),
+            ))),
+        )
+    }
+
+    fn pair_tree_hash(left: &Bytes, right: &Bytes) -> Bytes {
+        sha256(
+            Bytes::new(Some(BytesFromType::Raw(vec![2])))
+                .concat(left)
+                .concat(right),
+        )
+    }
+
+    fn cache_locations(
+        allocator: &Allocator,
+        cache: &mut HashMap<String, Srcloc>,
+        raw: NodePtr,
+        sexp: &ModernSExp,
+    ) -> Bytes {
+        let hash = match (allocator.sexp(raw), sexp) {
+            (SExp::Pair(raw_first, raw_rest), ModernSExp::Cons(_, first, rest)) => {
+                let first_hash = Self::cache_locations(allocator, cache, raw_first, first.as_ref());
+                let rest_hash = Self::cache_locations(allocator, cache, raw_rest, rest.as_ref());
+                Self::pair_tree_hash(&first_hash, &rest_hash)
+            }
+            (SExp::Atom, _) => sha256(Bytes::new(Some(BytesFromType::Raw(vec![1]))).concat(
+                &Bytes::new(Some(BytesFromType::Raw(
+                    allocator.atom(raw).as_ref().to_vec(),
+                ))),
+            )),
+            (SExp::Pair(_, _), _) => {
+                unreachable!("modern and raw S-expression representations diverged")
+            }
+        };
+        cache.entry(hash.hex()).or_insert_with(|| sexp.loc());
+        hash
+    }
+
+    fn import_with_cached_locations(
+        &self,
+        fallback_loc: &Srcloc,
+        node: NodePtr,
+    ) -> (Rc<ModernSExp>, Bytes) {
+        match self.allocator.sexp(node) {
+            SExp::Pair(first, rest) => {
+                let (first, first_hash) = self.import_with_cached_locations(fallback_loc, first);
+                let (rest, rest_hash) = self.import_with_cached_locations(fallback_loc, rest);
+                let hash = Self::pair_tree_hash(&first_hash, &rest_hash);
+                let loc = self
+                    .run_program_cache
+                    .get(&hash.hex())
+                    .cloned()
+                    .unwrap_or_else(|| fallback_loc.clone());
+                (Rc::new(ModernSExp::Cons(loc, first, rest)), hash)
+            }
+            SExp::Atom => {
+                let hash = self.atom_tree_hash(node);
+                let loc = self
+                    .run_program_cache
+                    .get(&hash.hex())
+                    .cloned()
+                    .unwrap_or_else(|| fallback_loc.clone());
+                let value = self.allocator.atom(node);
+                let value = value.as_ref();
+                let sexp = if value.is_empty() {
+                    ModernSExp::Nil(loc)
+                } else {
+                    let integer = number_from_u8(value);
+                    if u8_from_number(integer.clone()) == value {
+                        ModernSExp::Integer(loc, integer)
+                    } else {
+                        ModernSExp::Atom(loc, value.to_vec())
+                    }
+                };
+                (Rc::new(sexp), hash)
+            }
+        }
     }
 }
 
@@ -343,8 +424,18 @@ impl ClassicAllocator for SExpClassicAllocator {
         option: Option<RunProgramOption>,
     ) -> Result<(Cost, Self::NodePtr), ClError> {
         self.run_program_cache.clear();
-        build_swap_table_mut(&mut self.run_program_cache, program.sexp.as_ref());
-        build_swap_table_mut(&mut self.run_program_cache, args.sexp.as_ref());
+        Self::cache_locations(
+            &self.allocator,
+            &mut self.run_program_cache,
+            args.raw,
+            args.sexp.as_ref(),
+        );
+        Self::cache_locations(
+            &self.allocator,
+            &mut self.run_program_cache,
+            program.raw,
+            program.sexp.as_ref(),
+        );
 
         let loc = self.loc(program);
         let result = runner.run_program(&mut self.allocator, program.raw, args.raw, option);
@@ -356,20 +447,13 @@ impl ClassicAllocator for SExpClassicAllocator {
             }
         };
 
-        let imported = match self.import(loc, result.1) {
-            Ok(imported) => imported,
-            Err(err) => {
-                self.run_program_cache.clear();
-                return Err(err);
-            }
-        };
-        let relabeled = relabel(&self.run_program_cache, imported.sexp.as_ref());
+        let (relabeled, _) = self.import_with_cached_locations(&loc, result.1);
         self.run_program_cache.clear();
 
         Ok((
             result.0,
             SExpNode {
-                sexp: Rc::new(relabeled),
+                sexp: relabeled,
                 raw: result.1,
             },
         ))

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -3,7 +3,6 @@ use std::rc::Rc;
 
 use clvm_rs::allocator::{Allocator, NodePtr, SExp};
 use clvm_rs::error::EvalErr;
-use clvm_rs::reduction::Reduction;
 
 use crate::classic::clvm::__type_compatibility__::{Bytes, BytesFromType};
 use crate::classic::clvm::sexp::{enlist, first, map_m, proper_list, rest};
@@ -964,8 +963,10 @@ pub fn get_compile_filename(
 ) -> Result<Option<String>, EvalErr> {
     let cvt_prog = assemble(allocator, "(_get_compile_filename)")?;
 
-    let Reduction(_, cvt_prog_result) =
-        runner.run_program(allocator, cvt_prog, NodePtr::NIL, None)?;
+    let cvt_prog_result = allocator
+        .run_program(runner, &cvt_prog, &NodePtr::NIL, None)
+        .map_err(|err| err.1)?
+        .1;
 
     if cvt_prog_result == NodePtr::NIL {
         return Ok(None);
@@ -993,14 +994,15 @@ pub fn get_search_paths<A: ClassicAllocator>(
 where
     A::NodePtr: Clone,
 {
-    let search_paths_result = ((|| {
-        let search_paths_prog = assemble(allocator.allocator(), "(_get_include_paths)")?;
-        runner.run_program(allocator.allocator(), search_paths_prog, NodePtr::NIL, None)
-    })())
-    .map_err(|e| ClError(loc.clone(), e))?;
+    let search_paths_prog = assemble(allocator.allocator(), "(_get_include_paths)")
+        .map_err(|err| ClError(loc.clone(), err))?;
+    let search_paths_prog = allocator.import(loc.clone(), search_paths_prog)?;
+    let nil = allocator.import(loc, NodePtr::NIL)?;
+    let search_paths_result = allocator
+        .run_program(runner, &search_paths_prog, &nil, None)?
+        .1;
     let mut res = Vec::new();
-    let search_paths_result_import = allocator.import(loc, search_paths_result.1)?;
-    if let Some(l) = proper_list(allocator, &search_paths_result_import, true) {
+    if let Some(l) = proper_list(allocator, &search_paths_result, true) {
         for elt in l.iter() {
             if let ASExp::Atom = allocator.sexp(elt) {
                 // Only elt in scope.

--- a/src/classic/clvm_tools/stages/stage_2/defaults.rs
+++ b/src/classic/clvm_tools/stages/stage_2/defaults.rs
@@ -107,8 +107,9 @@ fn build_default_macro_lookup<A: ClassicAllocator>(
     eval_f: Rc<dyn TRunProgram>,
     macros_src: &[String],
 ) -> A::NodePtr {
-    let run = assemble(allocator.allocator(), "(a (com 2 3) 1)").unwrap();
     let macro_loc = Srcloc::start("*macros*");
+    let run = assemble(allocator.allocator(), "(a (com 2 3) 1)").unwrap();
+    let run = allocator.import(macro_loc.clone(), run).unwrap();
     let imported_nil = allocator.import(macro_loc.clone(), NodePtr::NIL).unwrap();
     let mut default_macro_lookup = imported_nil;
     for macro_src in macros_src {
@@ -121,18 +122,12 @@ fn build_default_macro_lookup<A: ClassicAllocator>(
                 &default_macro_lookup,
             )
             .unwrap();
-        let exported_env = allocator.export(&env);
-        let new_macro = eval_f
-            .run_program(allocator.allocator(), run, exported_env, None)
+        let new_macro = allocator
+            .run_program(eval_f.clone(), &run, &env, None)
             .unwrap()
             .1;
-        let imported_new_macro = allocator.import(macro_loc.clone(), new_macro).unwrap();
         default_macro_lookup = allocator
-            .new_pair(
-                macro_loc.clone(),
-                &imported_new_macro,
-                &default_macro_lookup,
-            )
+            .new_pair(macro_loc.clone(), &new_macro, &default_macro_lookup)
             .unwrap();
     }
     default_macro_lookup

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -225,12 +225,11 @@ where
     let loc = allocator.loc(name);
     let prog = assemble(allocator.allocator(), "(_read (_full_path_for_name 1))")
         .map_err(|e| ClError(loc.clone(), e))?;
-    let name_export = allocator.export(name);
-    let assembled_sexp = run_program
-        .run_program(allocator.allocator(), prog, name_export, None)
-        .map_err(|e| ClError(loc.clone(), e))?;
-    let assembled_sexp_import = allocator.import(loc.clone(), assembled_sexp.1)?;
-    if let Some(assembled) = proper_list(allocator, &assembled_sexp_import, true) {
+    let prog = allocator.import(loc.clone(), prog)?;
+    let assembled_sexp = allocator
+        .run_program(run_program.clone(), &prog, name, None)?
+        .1;
+    if let Some(assembled) = proper_list(allocator, &assembled_sexp, true) {
         for sexp in assembled {
             parse_mod_sexp(
                 allocator,
@@ -248,7 +247,10 @@ where
 
     Err(ClError(
         loc,
-        EvalErr::InternalError(name_export, "include returned malformed result".to_string()),
+        EvalErr::InternalError(
+            allocator.export(name),
+            "include returned malformed result".to_string(),
+        ),
     ))
 }
 
@@ -676,32 +678,25 @@ where
                                 produce_extra_info
                             )?;
 
-                        let compiled_export = allocator.export(&compiled);
-                        let loc = allocator.loc(&compiled);
-                        let compilation_result =
-                            run_program.run_program(
-                                allocator.allocator(),
-                                compiled_export,
-                                NodePtr::NIL,
-                                None
-                            ).map_err(|e| {
-                                ClError(loc.clone(), e)
-                            })?;
-
-                        let result =
-                            run_program.run_program(
-                                allocator.allocator(),
-                                compilation_result.1,
-                                NodePtr::NIL,
-                                None
-                            ).map_err(|e| {
-                                ClError(loc.clone(), e)
-                            })?;
-
-                        let result_imp = allocator.import(loc, result.1)?;
+                        let compilation_result = allocator
+                            .run_program(
+                                run_program.clone(),
+                                &compiled,
+                                &nil_import,
+                                None,
+                            )?
+                            .1;
+                        let result = allocator
+                            .run_program(
+                                run_program.clone(),
+                                &compilation_result,
+                                &nil_import,
+                                None,
+                            )?
+                            .1;
                         delayed_constants.remove(name);
                         result_collection.constants.insert(
-                            name.to_vec(), quote(allocator, &result_imp)?
+                            name.to_vec(), quote(allocator, &result)?
                         );
                     }
 
@@ -1037,10 +1032,8 @@ where
         )
         .map_err(|e| ClError(loc.clone(), e))?;
 
-        let exported_symbols = allocator.export(&symbols);
-        run_program
-            .run_program(allocator.allocator(), to_run, exported_symbols, None)
-            .map_err(|e| ClError(loc, e))?;
+        let to_run = allocator.import(loc, to_run)?;
+        allocator.run_program(run_program.clone(), &to_run, &symbols, None)?;
 
         Ok(opt_list)
     } else {
@@ -1066,17 +1059,17 @@ where
     let loc = allocator.loc(macro_lookup);
     let produce_extra_info_prog = assemble(allocator.allocator(), "(_symbols_extra_info)")
         .map_err(|e| ClError(loc.clone(), e))?;
-    let produce_extra_info_null = NodePtr::NIL;
-    let extra_info_res = run_program
+    let produce_extra_info_prog = allocator.import(loc.clone(), produce_extra_info_prog)?;
+    let produce_extra_info_null = allocator.import(loc, NodePtr::NIL)?;
+    let extra_info_res = allocator
         .run_program(
-            allocator.allocator(),
-            produce_extra_info_prog,
-            produce_extra_info_null,
+            run_program.clone(),
+            &produce_extra_info_prog,
+            &produce_extra_info_null,
             None,
-        )
-        .map_err(|e| ClError(loc.clone(), e))?;
-    let imported_extra_info = allocator.import(loc, extra_info_res.1)?;
-    let produce_extra_info = !allocator.is_nil(&imported_extra_info);
+        )?
+        .1;
+    let produce_extra_info = !allocator.is_nil(&extra_info_res);
 
     let cr = compile_mod_stage_1(
         allocator,

--- a/src/classic/clvm_tools/stages/stage_2/optimize.rs
+++ b/src/classic/clvm_tools/stages/stage_2/optimize.rs
@@ -123,11 +123,8 @@ where
         );
     }
     if sc_r && nn_r {
-        let r_export = allocator.export(r);
-        let res = runner
-            .run_program(allocator.allocator(), r_export, NodePtr::NIL, None)
-            .map_err(|e| ClError(allocator.loc(r), e))?;
-        let r1 = allocator.import(allocator.loc(r), res.1)?;
+        let nil = allocator.import(allocator.loc(r), NodePtr::NIL)?;
+        let r1 = allocator.run_program(runner, r, &nil, None)?.1;
         if DIAG_OPTIMIZATIONS {
             println!(
                 "CONSTANT_OPTIMIZER {} TO {}",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `ClassicAllocator::run_program` wrapper around `TRunProgram`
- cache raw CLVM input locations by tree hash for each execution and restore locations on matching result subtrees without changing their CLVM values
- clear the execution cache after both successful and failed runs
- route classic codegen compilation, macro, optimization, include, and symbol evaluation through the wrapper
- cover matching-location restoration and cache lifetime with a focused unit test

## Testing
- `cargo check`
- `cargo test run_program_restores_matching_locations_and_clears_its_cache`
- `cargo test test_equivalence_mandelbrot_classic`
- `cargo test test_classic_codegen_recursive_source_locations`
- `cargo test test_classic_codegen_function_call_with_rest_tail`
- `cargo test -- --skip compile_performance_suite` (706 passed; 0 failed; 1 ignored)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05f74d56-f18e-441e-90dc-baf3e86977ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05f74d56-f18e-441e-90dc-baf3e86977ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

