### PR TITLE
Add runner type to ClassicAllocator

### DIFF
--- a/src/classic/clvm_tools/debug.rs
+++ b/src/classic/clvm_tools/debug.rs
@@ -9,7 +9,6 @@ use crate::classic::clvm::serialize::sexp_to_stream;
 use crate::classic::clvm::sexp::{enlist, proper_list, rest, First, SelectNode, ThisNode};
 
 use crate::classic::clvm_tools::sha256tree::sha256tree;
-use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::{ClError, ClassicAllocator};
 
 use crate::compiler::comptypes::{CompileErr, CompilerOpts};
@@ -110,7 +109,7 @@ pub fn build_symbol_dump<A: ClassicAllocator>(
     allocator: &mut A,
     constants_lookup: &HashMap<Vec<u8>, A::NodePtr>,
     extra_function_data: &HashMap<Vec<u8>, FunctionExtraInfo<A>>,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
     extra_info: bool,
 ) -> Result<A::NodePtr, ClError>
 where

--- a/src/classic/clvm_tools/stages/stage_2/abstraction.rs
+++ b/src/classic/clvm_tools/stages/stage_2/abstraction.rs
@@ -7,6 +7,7 @@ use clvm_rs::error::EvalErr;
 
 use crate::classic::clvm::__type_compatibility__::bi_zero;
 use crate::classic::clvm_tools::binutils::disassemble;
+use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::compiler::sexp::SExp as ModernSExp;
 use crate::compiler::srcloc::Srcloc;
 use crate::util::{number_from_u8, u8_from_number};
@@ -53,6 +54,7 @@ impl<'a> BufCarrier<'a> for BufHolder<'a> {
 
 pub trait ClassicAllocator {
     type NodePtr;
+    type Runner: Clone + std::ops::Deref<Target = dyn TRunProgram>;
     fn loc(&self, node: &Self::NodePtr) -> Srcloc;
     fn sexp(&self, node: &Self::NodePtr) -> ASExp<Self::NodePtr>;
     fn atom<'a>(&'a self, node: &Self::NodePtr) -> BufHolder<'a>;
@@ -78,6 +80,7 @@ thread_local! {
 
 impl ClassicAllocator for Allocator {
     type NodePtr = clvmr::NodePtr;
+    type Runner = Rc<dyn TRunProgram>;
 
     fn loc(&self, _node: &Self::NodePtr) -> Srcloc {
         DEFAULT_SRCLOC.with(|s| s.clone())
@@ -192,6 +195,7 @@ impl SExpClassicAllocator {
 
 impl ClassicAllocator for SExpClassicAllocator {
     type NodePtr = SExpNode;
+    type Runner = Rc<dyn TRunProgram>;
 
     fn loc(&self, node: &Self::NodePtr) -> Srcloc {
         node.sexp.loc()

--- a/src/classic/clvm_tools/stages/stage_2/compile.rs
+++ b/src/classic/clvm_tools/stages/stage_2/compile.rs
@@ -47,7 +47,7 @@ struct Closure<'a, A: ClassicAllocator> {
         &A::NodePtr,
         &A::NodePtr,
         &A::NodePtr,
-        Rc<dyn TRunProgram>,
+        A::Runner,
         usize,
     ) -> Result<A::NodePtr, ClError>,
 }
@@ -99,7 +99,7 @@ fn com_qq<A: ClassicAllocator>(
     ident: String,
     macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     sexp: &A::NodePtr,
 ) -> Result<A::NodePtr, ClError>
 where
@@ -116,7 +116,7 @@ pub fn compile_qq<A: ClassicAllocator>(
     args: &A::NodePtr,
     macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     level: usize,
 ) -> Result<A::NodePtr, ClError>
 where
@@ -236,7 +236,7 @@ pub fn compile_macros<A: ClassicAllocator>(
     _args: &A::NodePtr,
     macro_lookup: &A::NodePtr,
     _symbol_table: &A::NodePtr,
-    _run_program: Rc<dyn TRunProgram>,
+    _run_program: A::Runner,
     _level: usize,
 ) -> Result<A::NodePtr, ClError>
 where
@@ -250,7 +250,7 @@ pub fn compile_symbols<A: ClassicAllocator>(
     _args: &A::NodePtr,
     _macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    _run_program: Rc<dyn TRunProgram>,
+    _run_program: A::Runner,
     _level: usize,
 ) -> Result<A::NodePtr, ClError>
 where
@@ -496,7 +496,7 @@ fn compile_operator_atom<A: ClassicAllocator>(
     avec: &[u8],
     macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<Option<A::NodePtr>, ClError>
 where
     A::NodePtr: Clone,
@@ -661,7 +661,7 @@ fn compile_application<A: ClassicAllocator>(
     rest: &A::NodePtr,
     macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -762,7 +762,7 @@ pub fn do_com_prog<A: ClassicAllocator>(
     prog: &A::NodePtr,
     macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -795,7 +795,7 @@ fn do_com_prog_<A: ClassicAllocator>(
     prog_: &A::NodePtr,
     macro_lookup: &A::NodePtr,
     symbol_table: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -894,7 +894,7 @@ where
 }
 
 pub fn do_com_prog_for_dialect<A: ClassicAllocator>(
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     allocator: &mut A,
     sexp: &A::NodePtr,
 ) -> Result<A::NodePtr, ClError>
@@ -986,7 +986,7 @@ pub fn get_compile_filename(
 }
 
 pub fn get_search_paths<A: ClassicAllocator>(
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     loc: Srcloc,
     allocator: &mut A,
 ) -> Result<Vec<String>, ClError>

--- a/src/classic/clvm_tools/stages/stage_2/defaults.rs
+++ b/src/classic/clvm_tools/stages/stage_2/defaults.rs
@@ -1,9 +1,6 @@
-use std::rc::Rc;
-
 use clvm_rs::allocator::NodePtr;
 
 use crate::classic::clvm_tools::binutils::assemble;
-use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::ClassicAllocator;
 use crate::compiler::srcloc::Srcloc;
 
@@ -104,7 +101,7 @@ fn default_macros_src() -> Vec<&'static str> {
 
 fn build_default_macro_lookup<A: ClassicAllocator>(
     allocator: &mut A,
-    eval_f: Rc<dyn TRunProgram>,
+    eval_f: A::Runner,
     macros_src: &[String],
 ) -> A::NodePtr {
     let run = assemble(allocator.allocator(), "(a (com 2 3) 1)").unwrap();
@@ -140,7 +137,7 @@ fn build_default_macro_lookup<A: ClassicAllocator>(
 
 pub fn default_macro_lookup<A: ClassicAllocator>(
     allocator: &mut A,
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
 ) -> A::NodePtr {
     let macro_srcs: Vec<String> = default_macros_src().iter().map(|s| s.to_string()).collect();
     build_default_macro_lookup(allocator, runner.clone(), &macro_srcs)

--- a/src/classic/clvm_tools/stages/stage_2/module.rs
+++ b/src/classic/clvm_tools/stages/stage_2/module.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::rc::Rc;
 
 use clvm_rs::allocator::NodePtr;
 use clvm_rs::error::EvalErr;
@@ -13,7 +12,6 @@ use crate::classic::clvm::sexp::{
 use crate::classic::clvm_tools::debug::{build_symbol_dump, FunctionExtraInfo};
 use crate::classic::clvm_tools::node_path::NodePath;
 use crate::classic::clvm_tools::stages::assemble;
-use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::{
     ASExp, BufCarrier, ClError, ClassicAllocator,
 };
@@ -217,7 +215,7 @@ fn parse_include<A: ClassicAllocator>(
     constants: &mut HashMap<Vec<u8>, A::NodePtr>,
     delayed_constants: &mut HashMap<Vec<u8>, A::NodePtr>,
     macros: &mut Vec<(Vec<u8>, A::NodePtr)>,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<(), ClError>
 where
     A::NodePtr: Clone,
@@ -460,7 +458,7 @@ fn parse_mod_sexp<A: ClassicAllocator>(
     // may call local functions (such as sha256tree).
     delayed_constants: &mut HashMap<Vec<u8>, A::NodePtr>,
     macros: &mut Vec<(Vec<u8>, A::NodePtr)>,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<(), ClError>
 where
     A::NodePtr: Clone,
@@ -563,7 +561,7 @@ fn compile_mod_stage_1<A: ClassicAllocator>(
     allocator: &mut A,
     args: &A::NodePtr,
     macro_lookup: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
     produce_extra_info: bool,
 ) -> Result<CollectionResult<A>, ClError>
 where
@@ -791,7 +789,7 @@ fn build_macro_lookup_program<A: ClassicAllocator>(
     allocator: &mut A,
     macro_lookup: &A::NodePtr,
     macros: &[(Vec<u8>, A::NodePtr)],
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -937,7 +935,7 @@ fn finish_compile_from_collection<A: ClassicAllocator>(
     allocator: &mut A,
     args: &A::NodePtr,
     macro_lookup: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
     cr: &CollectionResult<A>,
     produce_extra_info: bool,
 ) -> Result<A::NodePtr, ClError>
@@ -1056,7 +1054,7 @@ pub fn compile_mod<A: ClassicAllocator>(
     args: &A::NodePtr,
     macro_lookup: &A::NodePtr,
     _symbol_table: &A::NodePtr,
-    run_program: Rc<dyn TRunProgram>,
+    run_program: A::Runner,
     _level: usize,
 ) -> Result<A::NodePtr, ClError>
 where

--- a/src/classic/clvm_tools/stages/stage_2/optimize.rs
+++ b/src/classic/clvm_tools/stages/stage_2/optimize.rs
@@ -747,9 +747,12 @@ where
      */
     let optimizers: Vec<OptimizerRunner<A>> = vec![
         OptimizerRunner::new("cons_optimizer", &cons_optimizer),
-        OptimizerRunner::new("constant_optimizer", &|allocator, memo, r, eval_f| {
-            constant_optimizer(allocator, memo, r, 0, eval_f.clone())
-        }),
+        OptimizerRunner::new(
+            "constant_optimizer",
+            &|allocator, memo, r, eval_f: A::Runner| {
+                constant_optimizer(allocator, memo, r, 0, eval_f.clone())
+            },
+        ),
         OptimizerRunner::new("cons_q_a_optimizer", &cons_q_a_optimizer),
         OptimizerRunner::new(
             "var_change_optimizer_cons_eval",

--- a/src/classic/clvm_tools/stages/stage_2/optimize.rs
+++ b/src/classic/clvm_tools/stages/stage_2/optimize.rs
@@ -1,7 +1,6 @@
 use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
 use std::mem::swap;
-use std::rc::Rc;
 
 use clvm_rs::error::EvalErr;
 use num_bigint::ToBigInt;
@@ -14,7 +13,6 @@ use crate::classic::clvm::sexp::{enlist, equal_to, first, fold_m, map_m, proper_
 use crate::classic::clvm_tools::node_path::NodePath;
 use crate::classic::clvm_tools::pattern_match::match_sexp;
 use crate::classic::clvm_tools::stages::assemble;
-use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::{
     ASExp, BufCarrier, ClError, ClassicAllocator,
 };
@@ -91,7 +89,7 @@ pub fn constant_optimizer<A: ClassicAllocator>(
     _memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
     _max_cost: Cost,
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -162,7 +160,7 @@ pub fn cons_q_a_optimizer<A: ClassicAllocator>(
     allocator: &mut A,
     _memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    _eval_f: Rc<dyn TRunProgram>,
+    _eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -321,7 +319,7 @@ pub fn var_change_optimizer_cons_eval<A: ClassicAllocator>(
     allocator: &mut A,
     memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    eval_f: Rc<dyn TRunProgram>,
+    eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -451,7 +449,7 @@ pub fn children_optimizer<A: ClassicAllocator>(
     allocator: &mut A,
     memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    eval_f: Rc<dyn TRunProgram>,
+    eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -510,7 +508,7 @@ fn cons_optimizer<A: ClassicAllocator>(
     allocator: &mut A,
     _memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    _eval_f: Rc<dyn TRunProgram>,
+    _eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -563,7 +561,7 @@ fn path_optimizer<A: ClassicAllocator>(
     allocator: &mut A,
     _memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    _eval_f: Rc<dyn TRunProgram>,
+    _eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -625,7 +623,7 @@ fn quote_null_optimizer<A: ClassicAllocator>(
     allocator: &mut A,
     _memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    _eval_f: Rc<dyn TRunProgram>,
+    _eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -650,7 +648,7 @@ fn apply_null_optimizer<A: ClassicAllocator>(
     allocator: &mut A,
     _memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,
-    _eval_f: Rc<dyn TRunProgram>,
+    _eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -674,7 +672,7 @@ where
         &mut A,
         &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
         &A::NodePtr,
-        Rc<dyn TRunProgram>,
+        A::Runner,
     ) -> Result<A::NodePtr, ClError>,
 }
 
@@ -687,7 +685,7 @@ where
         allocator: &mut A,
         memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
         r: &A::NodePtr,
-        eval_f: Rc<dyn TRunProgram>,
+        eval_f: A::Runner,
     ) -> Result<A::NodePtr, ClError> {
         (self.to_run)(allocator, memo, r, eval_f)
     }
@@ -699,7 +697,7 @@ where
             &mut A,
             &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
             &A::NodePtr,
-            Rc<dyn TRunProgram>,
+            A::Runner,
         ) -> Result<A::NodePtr, ClError>,
     ) -> Self {
         OptimizerRunner {
@@ -713,7 +711,7 @@ pub fn optimize_sexp_<A: ClassicAllocator>(
     allocator: &mut A,
     memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r_: &A::NodePtr,
-    eval_f: Rc<dyn TRunProgram>,
+    eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -822,7 +820,7 @@ where
 pub fn optimize_sexp<A: ClassicAllocator>(
     allocator: &mut A,
     r: &A::NodePtr,
-    eval_f: Rc<dyn TRunProgram>,
+    eval_f: A::Runner,
 ) -> Result<A::NodePtr, ClError>
 where
     A::NodePtr: Clone,
@@ -844,7 +842,7 @@ where
 }
 
 pub fn do_optimize<A: ClassicAllocator>(
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     allocator: &mut A,
     memo: &RefCell<HashMap<AllocatorRefOrTreeHash, NodePtr>>,
     r: &A::NodePtr,

--- a/src/classic/clvm_tools/stages/stage_2/reader.rs
+++ b/src/classic/clvm_tools/stages/stage_2/reader.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::rc::Rc;
 
 use clvm_rs::error::EvalErr;
 use clvmr::allocator::NodePtr;
@@ -8,7 +7,6 @@ use crate::classic::clvm::__type_compatibility__::{Bytes, Stream, UnvalidatedByt
 use crate::classic::clvm::serialize::{sexp_from_stream, SimpleCreateCLVMObject};
 use crate::classic::clvm::sexp::{proper_list, rest};
 use crate::classic::clvm_tools::stages::assemble;
-use crate::classic::clvm_tools::stages::stage_0::TRunProgram;
 use crate::classic::clvm_tools::stages::stage_2::abstraction::{
     ASExp, BufCarrier, ClError, ClassicAllocator,
 };
@@ -62,7 +60,7 @@ where
 /// error nicely by using the form the user gave (parent_sexp) in the error
 /// report.
 pub fn read_file<A: ClassicAllocator>(
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     allocator: &mut A,
     parent_sexp: &A::NodePtr,
     filename: &str,
@@ -96,7 +94,7 @@ where
 /// as a constant or an error if the file wasn't found.
 pub fn process_embed_file<A: ClassicAllocator>(
     allocator: &mut A,
-    runner: Rc<dyn TRunProgram>,
+    runner: A::Runner,
     declaration_sexp: &A::NodePtr,
 ) -> Result<(Vec<u8>, A::NodePtr), ClError>
 where

--- a/src/tests/classic/stage_2.rs
+++ b/src/tests/classic/stage_2.rs
@@ -193,7 +193,7 @@ fn test_present_file_smoke_not_exists() {
         run_program_for_search_paths("*test*", &vec!["resources/tests".to_string()], false, 0);
     let sexp_triggering_read = assemble(&mut allocator, "(embed-file test-file sexp embed.sexp)")
         .expect("should assemble");
-    let res = read_file(
+    let res = read_file::<Allocator>(
         runner,
         &mut allocator,
         &sexp_triggering_read,
@@ -209,7 +209,7 @@ fn test_present_file_smoke_exists() {
         run_program_for_search_paths("*test*", &vec!["resources/tests".to_string()], false, 0);
     let sexp_triggering_read = assemble(&mut allocator, "(embed-file test-file sexp embed.sexp)")
         .expect("should assemble");
-    let res = read_file(runner, &mut allocator, &sexp_triggering_read, "embed.sexp")
+    let res = read_file::<Allocator>(runner, &mut allocator, &sexp_triggering_read, "embed.sexp")
         .expect("should exist");
     assert_eq!(decode_string(&res.data), "(23 24 25)");
 }
@@ -245,7 +245,7 @@ fn test_process_embed_file_as_sexp_in_an_unexpected_location() {
     );
     let sexp_triggering_read = assemble(&mut allocator, "(embed-file test-file hex act.clvm.hex)")
         .expect("should assemble");
-    let res = read_file(
+    let res = read_file::<Allocator>(
         runner,
         &mut allocator,
         &sexp_triggering_read,
@@ -266,7 +266,7 @@ fn test_process_embed_file_as_sexp_in_an_expected_location() {
     );
     let sexp_triggering_read = assemble(&mut allocator, "(embed-file test-file hex act.clvm.hex)")
         .expect("should assemble");
-    let res = read_file(
+    let res = read_file::<Allocator>(
         runner,
         &mut allocator,
         &sexp_triggering_read,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add an associated runner type to `ClassicAllocator`, constrained to clone and dereference to `TRunProgram`
- use `Rc<dyn TRunProgram>` for both existing allocator implementations
- update allocator-generic classic compiler functions to accept the associated runner type
- make affected test calls explicit where associated-type inference prevents runner coercion

## Testing
- `cargo check --all-targets`
- `cargo test --lib tests::classic::stage_2` (17 passed)
- `cargo test --lib -- --skip compile_performance_suite` (705 passed, 1 ignored, 1 filtered)
- `rustfmt --edition 2021 --check` on all changed Rust files

The unfiltered library suite reached only the existing long-running `compile_performance_suite`; it was stopped after the other tests completed and then rerun successfully with that performance test excluded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f03954f-d178-4e2b-b3f4-fd89b4e03089?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f03954f-d178-4e2b-b3f4-fd89b4e03089&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

